### PR TITLE
replace CurrencyTextBox by extended NumberTextBox

### DIFF
--- a/src/SimpleAccounting/Presentation/AddBookingView.xaml
+++ b/src/SimpleAccounting/Presentation/AddBookingView.xaml
@@ -6,7 +6,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:lg2de.SimpleAccounting.Presentation"
-    xmlns:currencytextboxcontrol="clr-namespace:CurrencyTextBoxControl;assembly=CurrencyTextbox"
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance Type=local:AddBookingDesignViewModel, IsDesignTimeCreatable=True}">
     <UserControl.InputBindings>
@@ -65,14 +64,15 @@
         <TextBlock
             Grid.Column="2" Grid.Row="1"
             HorizontalAlignment="Right" VerticalAlignment="Center"
-            Text="Wert" />
-        <currencytextboxcontrol:CurrencyTextBox
+            Text="Wert (€)" />
+        <local:NumberTextBox
             Grid.Column="3" Grid.Row="1"
             Width="100" Height="30"
             HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-            Number="{Binding BookingValue}" />
+            Scale="2"
+            Text="{Binding BookingValue, StringFormat='#0.00'}" />
 
-        <TabControl Grid.Row="2" Grid.ColumnSpan="4">
+        <TabControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4">
             <TabItem>
                 <TabItem.Header>
                     <TextBlock Text="Soll/Haben" Padding="2" />

--- a/src/SimpleAccounting/SimpleAccounting.csproj
+++ b/src/SimpleAccounting/SimpleAccounting.csproj
@@ -26,8 +26,6 @@
     <!-- license is MS-PL -->
     <PackageReference Include="CsvHelper" Version="12.2.3" />
     <!-- license is MIT -->
-    <PackageReference Include="CurrencyTextBox" Version="2.0.2" />
-    <!-- license is MIT -->
     <PackageReference Include="Octokit" Version="0.45.0" />
     <!-- license is LGPL -->
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.5.0.15942">


### PR DESCRIPTION
## Description
The package CurrencyTextBox provides implementation for a textbox accepting only numbers and to show currency symbol.
But I do not like the input behavior.
The NumberTextBox I created for "number only" text box could be simply extended for decimal numbers. The currency symbol is not required within the control, it can be shown besides.

## Related issue
Fixes #10 
