### PR TITLE
rewrite checking recent files for files on secured drive

### DIFF
--- a/src/SimpleAccounting/Infrastructure/AsyncCommand.cs
+++ b/src/SimpleAccounting/Infrastructure/AsyncCommand.cs
@@ -13,6 +13,16 @@ namespace lg2de.SimpleAccounting.Infrastructure
         private readonly IBusy busy;
         private readonly Func<Task> command;
 
+        public AsyncCommand(IBusy busy, Action command)
+        {
+            this.busy = busy;
+            this.command = () =>
+            {
+                command();
+                return Task.CompletedTask;
+            };
+        }
+
         public AsyncCommand(IBusy busy, Func<Task> command)
         {
             this.busy = busy;
@@ -35,7 +45,7 @@ namespace lg2de.SimpleAccounting.Infrastructure
             return true;
         }
 
-        public async Task ExecuteAsync(object parameter)
+        public async Task ExecuteAsync(object? parameter)
         {
             this.busy.IsBusy = true;
             RaiseCanExecuteChanged();

--- a/src/SimpleAccounting/Infrastructure/IAsyncCommand.cs
+++ b/src/SimpleAccounting/Infrastructure/IAsyncCommand.cs
@@ -9,6 +9,6 @@ namespace lg2de.SimpleAccounting.Infrastructure
 
     public interface IAsyncCommand : ICommand
     {
-        Task ExecuteAsync(object parameter);
+        Task ExecuteAsync(object? parameter);
     }
 }

--- a/src/SimpleAccounting/Infrastructure/OperationResult.cs
+++ b/src/SimpleAccounting/Infrastructure/OperationResult.cs
@@ -1,0 +1,13 @@
+﻿// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.Infrastructure
+{
+    internal enum OperationResult
+    {
+        Completed,
+        Failed,
+        Aborted
+    }
+}

--- a/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
+++ b/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
@@ -56,6 +56,7 @@ namespace lg2de.SimpleAccounting.Infrastructure
             {
                 if (!await this.CheckSecureDriveAsync(projectFileName))
                 {
+                    // TODO decide between NO and CANCEL
                     return false;
                 }
 

--- a/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
+++ b/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
@@ -50,19 +50,18 @@ namespace lg2de.SimpleAccounting.Infrastructure
         /// </remarks>
         public bool Migrated { get; private set; }
 
-        public async Task<bool> LoadAsync(string projectFileName)
+        public async Task<OperationResult> LoadAsync(string projectFileName)
         {
             try
             {
                 if (!await this.CheckSecureDriveAsync(projectFileName))
                 {
-                    // TODO decide between NO and CANCEL
-                    return false;
+                    return OperationResult.Aborted;
                 }
 
                 if (!this.LoadFile(projectFileName, out bool autoSaveFileLoaded))
                 {
-                    return false;
+                    return OperationResult.Failed;
                 }
 
                 if (this.ProjectData.Migrate() || autoSaveFileLoaded)
@@ -72,12 +71,12 @@ namespace lg2de.SimpleAccounting.Infrastructure
 
                 this.UpdateSettings(projectFileName);
 
-                return true;
+                return OperationResult.Completed;
             }
             catch (InvalidOperationException e)
             {
                 this.messageBox.Show($"Failed to load file '{projectFileName}':\n{e.Message}", "Load");
-                return false;
+                return OperationResult.Failed;
             }
         }
 

--- a/src/SimpleAccounting/Presentation/MenuViewModel.cs
+++ b/src/SimpleAccounting/Presentation/MenuViewModel.cs
@@ -4,11 +4,11 @@
 
 namespace lg2de.SimpleAccounting.Presentation
 {
-    using System.Windows.Input;
+    using lg2de.SimpleAccounting.Infrastructure;
 
     public class MenuViewModel
     {
-        public MenuViewModel(string header, ICommand command)
+        public MenuViewModel(string header, IAsyncCommand command)
         {
             this.Header = header;
             this.Command = command;
@@ -16,6 +16,6 @@ namespace lg2de.SimpleAccounting.Presentation
 
         public string Header { get; }
 
-        public ICommand Command { get; }
+        public IAsyncCommand Command { get; }
     }
 }

--- a/src/SimpleAccounting/Presentation/ShellViewModel.cs
+++ b/src/SimpleAccounting/Presentation/ShellViewModel.cs
@@ -529,6 +529,7 @@ namespace lg2de.SimpleAccounting.Presentation
             // keep in menu if aborted (e.g. SecureDrive not available)
             var item = this.RecentProjects.FirstOrDefault(x => x.Header == project);
             this.RecentProjects.Remove(item);
+            this.Settings.RecentProjects.Remove(project);
         }
 
         private async Task AutoSaveAsync()
@@ -764,7 +765,7 @@ namespace lg2de.SimpleAccounting.Presentation
             {
                 var menu = new MenuViewModel(
                     year.Year.ToString(CultureInfo.InvariantCulture),
-                    new RelayCommand(_ => this.SelectBookingYear(year.Year)));
+                    new AsyncCommand(this, () => this.SelectBookingYear(year.Year)));
                 this.BookingYears.Add(menu);
             }
         }

--- a/tests/SimpleAccounting.UnitTests/Infrastructure/ProjectFileLoaderTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Infrastructure/ProjectFileLoaderTests.cs
@@ -12,7 +12,6 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
     using FluentAssertions.Extensions;
     using lg2de.SimpleAccounting.Abstractions;
     using lg2de.SimpleAccounting.Infrastructure;
-    using lg2de.SimpleAccounting.Presentation;
     using lg2de.SimpleAccounting.Properties;
     using NSubstitute;
     using Xunit;
@@ -20,7 +19,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
     public class ProjectFileLoaderTests
     {
         [Fact]
-        public async Task LoadAsync_FileNotExists_ReturnsFalse()
+        public async Task LoadAsync_FileNotExists_ReturnsFailed()
         {
             var messageBox = Substitute.For<IMessageBox>();
             var fileSystem = Substitute.For<IFileSystem>();
@@ -30,11 +29,11 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
 
             var result = await sut.Awaiting(x => x.LoadAsync("the.fileName")).Should().CompleteWithinAsync(1.Seconds());
 
-            result.Subject.Should().BeFalse();
+            result.Subject.Should().Be(OperationResult.Failed);
         }
 
         [Fact]
-        public async Task LoadAsync_UserDoesNotWantToStartSecureDriveApp_ReturnsFalse()
+        public async Task LoadAsync_UserDoesNotWantToStartSecureDriveApp_ReturnsAborted()
         {
             var messageBox = Substitute.For<IMessageBox>();
             var fileSystem = Substitute.For<IFileSystem>();
@@ -50,7 +49,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
 
             var result = await sut.Awaiting(x => x.LoadAsync("K:\\the.fileName")).Should().CompleteWithinAsync(1.Seconds());
 
-            result.Subject.Should().BeFalse();
+            result.Subject.Should().Be(OperationResult.Aborted);
             processApi.DidNotReceive().Start(Arg.Any<ProcessStartInfo>());
             messageBox.Received(1).Show(
                 Arg.Is<string>(s => s.Contains("Cryptomator")),

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -8,6 +8,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading.Tasks;
     using System.Windows;
@@ -24,6 +25,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
     using NSubstitute;
     using Xunit;
 
+    [SuppressMessage("ReSharper", "StringLiteralTypo")]
     public partial class ShellViewModelTests
     {
         [Fact]
@@ -191,11 +193,62 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             var sut = CreateSut(out IFileSystem fileSystem);
             sut.Settings = new Settings { RecentProjects = new StringCollection { "file1", "file2" } };
             fileSystem.FileExists(Arg.Is("file1")).Returns(true);
+            fileSystem.FileExists(Arg.Is("file2")).Returns(false);
 
             ((IActivate)sut).Activate();
 
             // even the file is not available currently it should not be removed immediately from menu
             sut.RecentProjects.Select(x => x.Header).Should().Equal("file1", "file2");
+        }
+
+        [Fact]
+        public async Task RecentFileCommand_NonExisting_ProjectRemovedFromList()
+        {
+            var sut = CreateSut(out IFileSystem fileSystem);
+            sut.Settings = new Settings { RecentProjects = new StringCollection { "file1", "file2" } };
+            fileSystem.FileExists(Arg.Is("file1")).Returns(true);
+            fileSystem.FileExists(Arg.Is("file2")).Returns(false);
+            fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
+            ((IActivate)sut).Activate();
+            sut.RecentProjects.Select(x => x.Header).Should().Equal("file1", "file2");
+
+            foreach (var viewModel in sut.RecentProjects.ToList())
+            {
+                await viewModel.Command.ExecuteAsync(null);
+            }
+
+            sut.RecentProjects.Select(x => x.Header).Should().BeEquivalentTo("file1");
+            sut.Settings.RecentProjects.OfType<string>().Should().BeEquivalentTo("file1");
+        }
+
+        [Fact]
+        public async Task RecentFileCommand_FileOnSecureDriveNotStarted_ProjectKept()
+        {
+            var sut = CreateSut(out IMessageBox messageBox, out IFileSystem fileSystem);
+            sut.Settings = new Settings
+            {
+                RecentProjects = new StringCollection { "K:\\file1", "file2" },
+                SecuredDrives = new StringCollection { "K:\\" }
+            };
+            fileSystem.FileExists(Arg.Is("K:\\file1")).Returns(false);
+            fileSystem.FileExists(Arg.Is("file2")).Returns(true);
+            fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
+            messageBox.Show(
+                    Arg.Is<string>(s => s.Contains("Cryptomator")),
+                    Arg.Any<string>(),
+                    Arg.Any<MessageBoxButton>(), Arg.Any<MessageBoxImage>(),
+                    Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
+                .Returns(MessageBoxResult.No);
+            ((IActivate)sut).Activate();
+            sut.RecentProjects.Select(x => x.Header).Should().Equal("K:\\file1", "file2");
+
+            foreach (var viewModel in sut.RecentProjects)
+            {
+                await viewModel.Command.ExecuteAsync(null);
+            }
+
+            sut.RecentProjects.Select(x => x.Header).Should().BeEquivalentTo("K:\\file1", "file2");
+            sut.Settings.RecentProjects.OfType<string>().Should().BeEquivalentTo("K:\\file1", "file2");
         }
 
         [Fact]
@@ -364,7 +417,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         {
             var sut = CreateSut(out var messageBox, out var fileSystem);
             messageBox.Show(
-                    Arg.Any<string>(), Arg.Any<string>(),
+                    Arg.Is<string>(s => s.Contains("automatische Sicherung")), Arg.Any<string>(),
                     MessageBoxButton.YesNo, MessageBoxImage.Question,
                     Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
                 .Returns(MessageBoxResult.Yes);
@@ -389,7 +442,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         {
             var sut = CreateSut(out var messageBox, out var fileSystem);
             messageBox.Show(
-                    Arg.Any<string>(), Arg.Any<string>(),
+                    Arg.Is<string>(s => s.Contains("automatische Sicherung")), Arg.Any<string>(),
                     MessageBoxButton.YesNo, MessageBoxImage.Question,
                     Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
                 .Returns(MessageBoxResult.No);
@@ -519,6 +572,30 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
                 .Which.Should().Be(OperationResult.Completed);
 
             sut.IsDocumentModified.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task LoadProjectFromFileAsync_UserDoesNotWantSaveCurrentProject_LoadingAborted()
+        {
+            var sut = CreateSut(out var messageBox, out var fileSystem);
+            sut.FileName = "old.fileName";
+            sut.IsDocumentModified = true;
+            messageBox.Show(
+                    Arg.Is<string>(s => s.Contains("Die Datenbasis hat sich geändert.")), Arg.Any<string>(),
+                    MessageBoxButton.YesNo, MessageBoxImage.Question,
+                    Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
+                .Returns(MessageBoxResult.Cancel);
+            fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
+            fileSystem.FileExists("new.fileName").Returns(true);
+
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Aborted);
+
+            using var _ = new AssertionScope();
+            sut.FileName.Should().Be("old.fileName", "the new file was not loaded");
+            sut.IsDocumentModified.Should().BeTrue("changes are (still) not yet saved");
+            fileSystem.DidNotReceive().ReadAllTextFromFile("the.fileName");
         }
 
         [Fact]

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -186,7 +186,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         }
 
         [Fact]
-        public void OnActivate_TwoRecentProjectsOneExisting_ExistingProjectListed()
+        public void OnActivate_TwoRecentProjectsOneExisting_AllProjectListed()
         {
             var sut = CreateSut(out IFileSystem fileSystem);
             sut.Settings = new Settings { RecentProjects = new StringCollection { "file1", "file2" } };
@@ -194,7 +194,8 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
 
             ((IActivate)sut).Activate();
 
-            sut.RecentProjects.Select(x => x.Header).Should().Equal("file1");
+            // even the file is not available currently it should not be removed immediately from menu
+            sut.RecentProjects.Select(x => x.Header).Should().Equal("file1", "file2");
         }
 
         [Fact]
@@ -346,7 +347,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.FileExists("the.fileName").Returns(true);
             fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
 
-            await sut.LoadProjectFromFileAsync("the.fileName");
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             using var _ = new AssertionScope();
             sut.FileName.Should().Be("the.fileName");
@@ -369,7 +372,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.FileExists("the.fileName").Returns(true);
             fileSystem.FileExists("the.fileName~").Returns(true);
 
-            await sut.LoadProjectFromFileAsync("the.fileName");
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             using var _ = new AssertionScope();
             sut.FileName.Should().Be("the.fileName");
@@ -392,8 +397,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.FileExists("the.fileName").Returns(true);
             fileSystem.FileExists("the.fileName~").Returns(true);
 
-            await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
-                .CompleteWithinAsync(1.Seconds());
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             using var _ = new AssertionScope();
             sut.FileName.Should().Be("the.fileName");
@@ -412,8 +418,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.GetDrives().Returns(
                 new[] { (FilePath: "C:\\", Format: "Normal"), (FilePath: "K:\\", Format: "Cryptomator File System") });
 
-            await sut.Awaiting(x => x.LoadProjectFromFileAsync("K:\\the.fileName")).Should()
-                .CompleteWithinAsync(1.Seconds());
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("K:\\the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             sut.Settings.SecuredDrives.Should().Equal(new object[] { "K:\\" });
             messageBox.DidNotReceive().Show(
@@ -461,8 +468,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             processApi.When(x => x.BringProcessToFront(Arg.Any<Process>())).Do(info => securedFileAvailable = true);
             fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
 
-            await sut.Awaiting(x => x.LoadProjectFromFileAsync("K:\\the.fileName")).Should()
-                .CompleteWithinAsync(1.Seconds());
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("K:\\the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             fileSystem.Received(1).ReadAllTextFromFile("K:\\the.fileName");
         }
@@ -487,7 +495,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.FileExists("the.fileName").Returns(true);
             fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
 
-            await sut.LoadProjectFromFileAsync("the.fileName");
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             sut.Settings.RecentProjects.OfType<string>().Should()
                 .Equal("the.fileName", "A", "B", "C", "D", "E", "F", "G", "H", "I");
@@ -504,7 +514,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.FileExists("the.fileName").Returns(true);
             fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(accountingData.Serialize());
 
-            await sut.LoadProjectFromFileAsync("the.fileName");
+            (await sut.Awaiting(x => x.LoadProjectFromFileAsync("the.fileName")).Should()
+                    .CompleteWithinAsync(1.Seconds()))
+                .Which.Should().Be(OperationResult.Completed);
 
             sut.IsDocumentModified.Should().BeTrue();
         }


### PR DESCRIPTION
## Description
If one or more project files are stored on a secure drive (like Cryptomator) the file may not yet be available.
If another project file is loaded these files may be dropped from recent file list because there was no chance to open secure drive.
Checking for available files needs to be "improved"...