### PR TITLE
improve performance of drive type analysis

### DIFF
--- a/src/SimpleAccounting/Abstractions/FileSystem.cs
+++ b/src/SimpleAccounting/Abstractions/FileSystem.cs
@@ -50,15 +50,14 @@ namespace lg2de.SimpleAccounting.Abstractions
             return File.ReadAllText(path);
         }
 
-        public IEnumerable<(string RootPath, string Format)> GetDrives()
+        public IEnumerable<(string RootPath, Func<string> GetFormat)> GetDrives()
         {
             foreach (var driveInfo in DriveInfo.GetDrives())
             {
-                (string RootPath, string Format) info;
+                (string RootPath, Func<string> GetFormat) info;
                 try
                 {
-                    // TODO implement cache for DriveFormat which is time consuming
-                    info = (RootPath: driveInfo.RootDirectory.FullName, Format: driveInfo.DriveFormat);
+                    info = (RootPath: driveInfo.RootDirectory.FullName, GetFormat: () => driveInfo.DriveFormat);
                 }
                 catch (IOException)
                 {

--- a/src/SimpleAccounting/Abstractions/IFileSystem.cs
+++ b/src/SimpleAccounting/Abstractions/IFileSystem.cs
@@ -61,6 +61,6 @@ namespace lg2de.SimpleAccounting.Abstractions
         ///     Retrieves the drive names of all logical drives on a computer.
         /// </summary>
         /// <returns>An enumeration of type <see cref="System.IO.DriveInfo"/> that represents the logical drives on a computer.</returns>
-        IEnumerable<(string RootPath, string Format)> GetDrives();
+        IEnumerable<(string RootPath, Func<string> GetFormat)> GetDrives();
     }
 }

--- a/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
+++ b/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
@@ -166,8 +166,8 @@ namespace lg2de.SimpleAccounting.Infrastructure
 
             var info = this.fileSystem.GetDrives().SingleOrDefault(
                 x => projectFileName.StartsWith(x.RootPath, StringComparison.InvariantCultureIgnoreCase));
-            if (info.Format != null
-                && info.Format.Contains("cryptomator", StringComparison.InvariantCultureIgnoreCase)
+            string format = info.GetFormat?.Invoke() ?? string.Empty;
+            if (format.Contains("cryptomator", StringComparison.InvariantCultureIgnoreCase)
                 && !this.settings.SecuredDrives.Contains(info.RootPath))
             {
                 this.settings.SecuredDrives.Add(info.RootPath);

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -505,7 +505,12 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             fileSystem.FileExists(Arg.Is("K:\\the.fileName")).Returns(true);
             fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
             fileSystem.GetDrives().Returns(
-                new[] { (FilePath: "C:\\", Format: "Normal"), (FilePath: "K:\\", Format: "Cryptomator File System") });
+                x =>
+                {
+                    var func1 = new Func<string>(() => "Normal");
+                    var func2 = new Func<string>(() => "Cryptomator File System");
+                    return new[] { (FilePath: "C:\\", GetFormat: func1), (FilePath: "K:\\", GetFormat: func2) };
+                });
 
             (await sut.Awaiting(x => x.LoadProjectFromFileAsync("K:\\the.fileName")).Should()
                     .CompleteWithinAsync(1.Seconds()))


### PR DESCRIPTION
## Description
For detection of secured devices (like Cryptomator drive) all drives are checked. This very time consuming with many (network) drives. This causes strong delay on application start.
But drive information is not really needed for all, but only selected.

