### PR TITLE
Prevent selecting date outside the booking year

### DIFF
--- a/src/SimpleAccounting/Presentation/EditBookingDesignViewModel.cs
+++ b/src/SimpleAccounting/Presentation/EditBookingDesignViewModel.cs
@@ -17,7 +17,7 @@ namespace lg2de.SimpleAccounting.Presentation
     internal class EditBookingDesignViewModel : EditBookingViewModel
     {
         public EditBookingDesignViewModel()
-            : base(null!, DateTime.Now, DateTime.Now, editMode: false)
+            : base(null!, DateTime.Now, DateTime.Now, DateTime.Now, editMode: false)
         {
             this.BookingIdentifier = 42;
             this.BookingText = "shoes";

--- a/src/SimpleAccounting/Presentation/EditBookingView.xaml
+++ b/src/SimpleAccounting/Presentation/EditBookingView.xaml
@@ -51,7 +51,9 @@
     </Grid.Resources>
     <DatePicker
       Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0"
-      SelectedDate="{Binding Date}" />
+      SelectedDate="{Binding Date}"
+      DisplayDateStart="{Binding DateStart, Mode=OneWay}"
+      DisplayDateEnd="{Binding DateEnd, Mode=OneWay}" />
     <TextBlock
       Grid.Column="2" Grid.Row="0"
       HorizontalAlignment="Right" VerticalAlignment="Center"

--- a/src/SimpleAccounting/Presentation/EditBookingViewModel.cs
+++ b/src/SimpleAccounting/Presentation/EditBookingViewModel.cs
@@ -23,12 +23,28 @@ namespace lg2de.SimpleAccounting.Presentation
         private ulong debitAccount;
         private BookingTemplate? selectedTemplate;
 
-        public EditBookingViewModel(ShellViewModel parent, DateTime dateStart, DateTime dateEnd, bool editMode = false)
+        public EditBookingViewModel(
+            ShellViewModel parent,
+            DateTime date,
+            DateTime dateStart,
+            DateTime dateEnd,
+            bool editMode = false)
         {
             this.EditMode = editMode;
             this.parent = parent;
+            this.Date = date;
             this.DateStart = dateStart;
             this.DateEnd = dateEnd;
+
+            if (this.Date > this.DateEnd)
+            {
+                this.Date = this.DateEnd;
+            }
+
+            if (this.Date < this.DateStart)
+            {
+                this.Date = this.DateStart;
+            }
 
             this.CreditSplitEntries.CollectionChanged +=
                 (sender, args) =>
@@ -58,7 +74,11 @@ namespace lg2de.SimpleAccounting.Presentation
 
         public List<AccountDefinition> ExpenseRemoteAccounts { get; private set; } = new List<AccountDefinition>();
 
-        public DateTime Date { get; set; } = DateTime.Today;
+        public DateTime Date { get; set; }
+
+        public DateTime DateStart { get; }
+
+        public DateTime DateEnd { get; }
 
         public ulong BookingIdentifier { get; set; }
 
@@ -185,10 +205,6 @@ namespace lg2de.SimpleAccounting.Presentation
                     this.AddCommand.Execute(null);
                 }
             });
-
-        internal DateTime DateStart { get; }
-
-        internal DateTime DateEnd { get; }
 
         public AccountingDataJournalBooking CreateJournalEntry()
         {

--- a/src/SimpleAccounting/Presentation/ShellViewModel.cs
+++ b/src/SimpleAccounting/Presentation/ShellViewModel.cs
@@ -669,11 +669,15 @@ namespace lg2de.SimpleAccounting.Presentation
 
         private void OnAddBookings()
         {
+            var yearStart = this.currentModelJournal!.DateStart.ToDateTime();
+            var yearEnd = this.currentModelJournal.DateEnd.ToDateTime();
             var bookingModel = new EditBookingViewModel(
                 this,
-                this.currentModelJournal!.DateStart.ToDateTime(),
-                this.currentModelJournal.DateEnd.ToDateTime(),
-                editMode: false) { BookingIdentifier = this.GetMaxBookIdent() + 1 };
+                DateTime.Today,
+                yearStart,
+                yearEnd,
+                editMode: false)
+            { BookingIdentifier = this.GetMaxBookIdent() + 1 };
             var allAccounts = this.accountingData!.AllAccounts;
             bookingModel.Accounts.AddRange(this.ShowInactiveAccounts ? allAccounts : allAccounts.Where(x => x.Active));
 
@@ -707,12 +711,12 @@ namespace lg2de.SimpleAccounting.Presentation
 
             var bookingModel = new EditBookingViewModel(
                 this,
+                journalEntry.Date.ToDateTime(),
                 this.currentModelJournal!.DateStart.ToDateTime(),
                 this.currentModelJournal.DateEnd.ToDateTime(),
                 editMode: true)
             {
                 BookingIdentifier = journalEntry.ID,
-                Date = journalEntry.Date.ToDateTime(),
                 IsFollowup = journalEntry.Followup,
                 IsOpening = journalEntry.Opening
             };

--- a/tests/SimpleAccounting.UnitTests/Presentation/EditBookingViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/EditBookingViewModelTests.cs
@@ -24,6 +24,30 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         private static readonly DateTime YearEnd = new DateTime(DateTime.Now.Year, 12, 31);
 
         [Fact]
+        public void Ctor_DateBeforeStart_DateLimited()
+        {
+            var sut = new EditBookingViewModel(null!, YearBegin - TimeSpan.FromDays(1), YearBegin, YearEnd);
+
+            sut.Date.Should().Be(YearBegin);
+        }
+
+        [Fact]
+        public void Ctor_DateAfterStart_DateCorrect()
+        {
+            var sut = new EditBookingViewModel(null!, YearBegin + TimeSpan.FromDays(1), YearBegin, YearEnd);
+
+            sut.Date.Should().Be(YearBegin + TimeSpan.FromDays(1));
+        }
+
+        [Fact]
+        public void Ctor_DateAfterEnd_DateLimited()
+        {
+            var sut = new EditBookingViewModel(null!, YearEnd + TimeSpan.FromDays(1), YearBegin, YearEnd);
+
+            sut.Date.Should().Be(YearEnd);
+        }
+
+        [Fact]
         public void AddCommand_FirstBooking_BookingNumberIncremented()
         {
             var windowManager = Substitute.For<IWindowManager>();
@@ -35,7 +59,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             var parent = new ShellViewModel(
                 windowManager, reportFactory, applicationUpdate, messageBox, fileSystem, processApi);
             parent.LoadProjectData(Samples.SampleProject);
-            var sut = new EditBookingViewModel(parent, YearBegin, YearEnd);
+            var sut = new EditBookingViewModel(parent, YearBegin, YearBegin, YearEnd);
 
             var oldNumber = sut.BookingIdentifier;
             sut.CreditAccount = 100;
@@ -51,7 +75,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_InvalidYear_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -67,7 +91,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_MissingCredit_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -81,7 +105,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_MissingDebit_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -95,7 +119,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_MissingNumber_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingText = "abc",
                 CreditIndex = 1,
@@ -109,7 +133,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_MissingText_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 CreditIndex = 1,
@@ -123,7 +147,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_MissingValue_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -137,7 +161,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_SameAccount_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -152,7 +176,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_ValidValues_CanExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -167,7 +191,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_ConsistentCreditSplitBooking_CanExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -187,7 +211,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_ConsistentDebitSplitBooking_CanExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -207,7 +231,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_InconsistentDebitSplitBooking_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -227,7 +251,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_SplitBookingWithZeroValue_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -247,7 +271,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_SplitBookingMissingText_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -267,7 +291,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_SplitBookingMissingAccount_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -287,7 +311,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_SplitBookingSameAccount_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -307,7 +331,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void AddCommand_SplitBookingNonMatchingValues_CannotExecute()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 1,
                 BookingText = "abc",
@@ -327,7 +351,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void OnInitialize_Initialized()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd);
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd);
 
             ((IActivate)sut).Activate();
 
@@ -338,7 +362,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void OnInitialize_AllAccountTypesAdded_AccountRelatedPropertiesNotEmpty()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd);
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd);
             foreach (AccountDefinitionType type in Enum.GetValues(typeof(AccountDefinitionType)))
             {
                 sut.Accounts.Add(new AccountDefinition { Name = type.ToString(), Type = type });
@@ -357,7 +381,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void SelectedTemplate_SetNull_PropertiesUnchanged()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 CreditAccount = 1,
                 DebitAccount = 2,
@@ -381,7 +405,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void SelectedTemplate_SetTemplateWithCredit_CreditAccountSet()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 CreditAccount = 1,
                 DebitAccount = 2,
@@ -405,7 +429,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void SelectedTemplate_SetTemplateWithDebit_DebitAccountSet()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 CreditAccount = 1,
                 DebitAccount = 2,
@@ -429,7 +453,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void SelectedTemplate_SetTemplateWithValue_ValueSet()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 CreditAccount = 1,
                 DebitAccount = 2,
@@ -454,7 +478,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void CreateJournalEntry_SplitCreditEntries_JournalEntryCorrect()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 42, Date = new DateTime(2020, 6, 20)
             };
@@ -488,7 +512,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void CreateJournalEntry_SplitSingleCreditEntry_JournalEntryCorrect()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 42, Date = new DateTime(2020, 6, 20)
             };
@@ -519,7 +543,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void CreateJournalEntry_SplitDebitEntries_JournalEntryCorrect()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 42, Date = new DateTime(2020, 6, 20)
             };
@@ -553,7 +577,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void CreateJournalEntry_SplitSingleDebitEntry_JournalEntryCorrect()
         {
-            var sut = new EditBookingViewModel(null!, YearBegin, YearEnd)
+            var sut = new EditBookingViewModel(null!, YearBegin, YearBegin, YearEnd)
             {
                 BookingIdentifier = 42, Date = new DateTime(2020, 6, 20)
             };


### PR DESCRIPTION
## Description
When opening the booking dialog after end date of booking year, the dialog is initialized with invalid date: outside the range.
Further, selecting date outside the booking year range should not be possible.

Introduced limitation feature of `DatePicker` and fixed initialization.