### PR TITLE
Add more error handling to update procedure to identify failures

### DIFF
--- a/src/SimpleAccounting/Extensions/GithubReleaseExtensions.cs
+++ b/src/SimpleAccounting/Extensions/GithubReleaseExtensions.cs
@@ -11,7 +11,7 @@ namespace lg2de.SimpleAccounting.Extensions
 
     internal static class GithubReleaseExtensions
     {
-        public static Release GetNewRelease(this IEnumerable<Release> releases, string currentVersion)
+        public static Release? GetNewRelease(this IEnumerable<Release> releases, string currentVersion)
         {
             bool isPreRelease = currentVersion.Contains("beta", StringComparison.InvariantCultureIgnoreCase);
             var candidates = releases.Where(x => !x.Draft);
@@ -59,6 +59,5 @@ namespace lg2de.SimpleAccounting.Extensions
                 return false;
             }
         }
-
     }
 }

--- a/src/SimpleAccounting/Infrastructure/ApplicationUpdate.cs
+++ b/src/SimpleAccounting/Infrastructure/ApplicationUpdate.cs
@@ -33,13 +33,15 @@ namespace lg2de.SimpleAccounting.Infrastructure
             this.process = process;
         }
 
+        internal int WaitTimeMilliseconds { get; set; } = 5000;
+
         public async Task<bool> IsUpdateAvailableAsync(string currentVersion)
         {
             IEnumerable<Release> releases = await this.GetAllReleasesAsync();
             return this.AskForUpdate(releases, currentVersion);
         }
 
-        public void StartUpdateProcess()
+        public bool StartUpdateProcess()
         {
             if (this.newRelease == null)
             {
@@ -52,7 +54,7 @@ namespace lg2de.SimpleAccounting.Infrastructure
             if (stream == null)
             {
                 // script not found :(
-                return;
+                return false;
             }
 
             using var reader = new StreamReader(stream);
@@ -66,7 +68,7 @@ namespace lg2de.SimpleAccounting.Infrastructure
             if (asset == null)
             {
                 // asset not found :(
-                return;
+                return false;
             }
 
             string assetUrl = asset.BrowserDownloadUrl;
@@ -75,7 +77,17 @@ namespace lg2de.SimpleAccounting.Infrastructure
             var info = new ProcessStartInfo(
                 "powershell",
                 $"-File {scriptPath} -assetUrl {assetUrl} -targetFolder {targetFolder} -processId {processId}");
-            this.process.Start(info);
+            var updateProcess = this.process.Start(info);
+
+            var exited = updateProcess.WaitForExit(this.WaitTimeMilliseconds);
+            if (!exited)
+            {
+                return true;
+            }
+
+            var message = string.Format(Resources.Update_ProcessFailed, updateProcess.ExitCode);
+            this.messageBox.Show(message, Resources.Header_CheckForUpdates, icon: MessageBoxImage.Error);
+            return false;
         }
 
         [SuppressMessage(

--- a/src/SimpleAccounting/Infrastructure/ApplicationUpdate.cs
+++ b/src/SimpleAccounting/Infrastructure/ApplicationUpdate.cs
@@ -85,7 +85,8 @@ namespace lg2de.SimpleAccounting.Infrastructure
                 return true;
             }
 
-            var message = string.Format(Resources.Update_ProcessFailed, updateProcess.ExitCode);
+            var message = string.Format(
+                CultureInfo.CurrentUICulture, Resources.Update_ProcessFailed, updateProcess.ExitCode);
             this.messageBox.Show(message, Resources.Header_CheckForUpdates, icon: MessageBoxImage.Error);
             return false;
         }
@@ -125,9 +126,10 @@ namespace lg2de.SimpleAccounting.Infrastructure
                 return false;
             }
 
+            string message = string.Format(
+                CultureInfo.CurrentUICulture, Resources.Question_UpdateToVersionX, this.newRelease.TagName);
             var result = this.messageBox.Show(
-                string.Format(
-                    CultureInfo.CurrentUICulture, Resources.Question_UpdateToVersionX, this.newRelease.TagName),
+                message,
                 caption,
                 MessageBoxButton.YesNo,
                 MessageBoxImage.Question,

--- a/src/SimpleAccounting/Infrastructure/IApplicationUpdate.cs
+++ b/src/SimpleAccounting/Infrastructure/IApplicationUpdate.cs
@@ -10,6 +10,6 @@ namespace lg2de.SimpleAccounting.Infrastructure
     {
         Task<bool> IsUpdateAvailableAsync(string currentVersion);
 
-        void StartUpdateProcess();
+        bool StartUpdateProcess();
     }
 }

--- a/src/SimpleAccounting/Presentation/ShellViewModel.cs
+++ b/src/SimpleAccounting/Presentation/ShellViewModel.cs
@@ -490,7 +490,10 @@ namespace lg2de.SimpleAccounting.Presentation
 
             // starts separate process to update application in-place
             // Now we need to close this application.
-            this.applicationUpdate.StartUpdateProcess();
+            if (!this.applicationUpdate.StartUpdateProcess())
+            {
+                return;
+            }
 
             // The user was asked whether saving the project (CheckSaveProject).
             // It may have answered "No". So, the project may still be modified.

--- a/src/SimpleAccounting/Properties/Resources.Designer.cs
+++ b/src/SimpleAccounting/Properties/Resources.Designer.cs
@@ -517,7 +517,7 @@ namespace lg2de.SimpleAccounting.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Send feedback.
+        ///   Looks up a localized string similar to Create feedback.
         /// </summary>
         public static string Menu_Help_Feedback {
             get {
@@ -764,6 +764,15 @@ namespace lg2de.SimpleAccounting.Properties {
         public static string Tooltip_SplitBookingValue {
             get {
                 return ResourceManager.GetString("Tooltip_SplitBookingValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        public static string Update_ProcessFailed {
+            get {
+                return ResourceManager.GetString("Update_ProcessFailed", resourceCulture);
             }
         }
         

--- a/src/SimpleAccounting/Properties/Resources.de.resx
+++ b/src/SimpleAccounting/Properties/Resources.de.resx
@@ -512,4 +512,7 @@ Mit 'Nein' wird diese Sicherung gelöscht.</value>
   <data name="Question_UpdateToVersionX" xml:space="preserve">
     <value>Wollen Sie auf die neue Version {0} aktualisieren?</value>
   </data>
+  <data name="Update_ProcessFailed" xml:space="preserve">
+    <value>Der Aktualisierungsprozess ist mit dem Fehlercode {0} fehlgeschlagen.</value>
+  </data>
 </root>

--- a/src/SimpleAccounting/Properties/Resources.resx
+++ b/src/SimpleAccounting/Properties/Resources.resx
@@ -524,4 +524,7 @@ When answering 'No' the backup file will be deleted.</value>
   <data name="Question_UpdateToVersionX" xml:space="preserve">
     <value>Do you want to update to version {0}?</value>
   </data>
+  <data name="Update_ProcessFailed" xml:space="preserve">
+    <value>The update process failed with exit code {0}.</value>
+  </data>
 </root>

--- a/src/SimpleAccounting/UpdateApplication.ps1
+++ b/src/SimpleAccounting/UpdateApplication.ps1
@@ -4,13 +4,17 @@
   [Parameter(Mandatory=$true)][int]$processId
 )
 
-$tempFile = $env:TEMP + "\package.zip"
-Remove-Item $tempFile -ErrorAction SilentlyContinue
-
-Write-Host Waiting for current application to finish...
-Wait-Process -Id $processId -ErrorAction SilentlyContinue
+$ErrorActionPreference = "Stop"
 
 try {
+  Write-Host Updating SimpleAccounting...
+
+  $tempFile = $env:TEMP + "\package.zip"
+  Remove-Item $tempFile -ErrorAction SilentlyContinue
+
+  Write-Host Waiting for current application to finish...
+  Wait-Process -Id $processId -ErrorAction SilentlyContinue
+
   Write-Host Download new release...
   Write-Host $assetUrl
   Invoke-WebRequest -Uri $assetUrl -OutFile $tempFile

--- a/tests/SimpleAccounting.UnitTests/Infrastructure/ApplicationUpdateTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Infrastructure/ApplicationUpdateTests.cs
@@ -100,7 +100,12 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
             var messageBox = Substitute.For<IMessageBox>();
             var fileSystem = Substitute.For<IFileSystem>();
             var processApi = Substitute.For<IProcess>();
-            var sut = new ApplicationUpdate(messageBox, fileSystem, processApi);
+            processApi.Start(Arg.Any<ProcessStartInfo>())
+                .Returns(Process.Start(new ProcessStartInfo("cmd.exe", "/c ping 127.0.0.1")));
+            var sut = new ApplicationUpdate(messageBox, fileSystem, processApi)
+            {
+                WaitTimeMilliseconds = 0
+            };
             var releases = GithubReleaseExtensionTests.CreateRelease("2.1");
             messageBox.Show(
                     Arg.Any<string>(),
@@ -110,7 +115,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
                 .Returns(MessageBoxResult.Yes);
             sut.AskForUpdate(releases, "2.0").Should().BeTrue();
 
-            sut.StartUpdateProcess();
+            sut.StartUpdateProcess().Should().BeTrue();
 
             fileSystem.Received(1).WriteAllTextIntoFile(
                 Arg.Is<string>(x => x.Contains(Path.GetTempPath())), Arg.Any<string>());

--- a/tests/SimpleAccounting.UnitTests/Infrastructure/ApplicationUpdateTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Infrastructure/ApplicationUpdateTests.cs
@@ -123,7 +123,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
             processApi.Received(1).Start(Arg.Is<ProcessStartInfo>(i => i.FileName == "powershell"));
         }
 
-        [Fact]
+        [CulturedFact("en")]
         public void StartUpdateProcess_UpdateProcessFailed_UpdateAborted()
         {
             var messageBox = Substitute.For<IMessageBox>();
@@ -140,7 +140,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Infrastructure
 
             sut.StartUpdateProcess().Should().BeFalse();
             messageBox.Received(1).Show(
-                Arg.Is<string>(s => s.Contains(" 5 ")), Resources.Header_CheckForUpdates, icon: MessageBoxImage.Error);
+                Arg.Is<string>(s => s.Contains("code 5.")), Resources.Header_CheckForUpdates, icon: MessageBoxImage.Error);
         }
     }
 }

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -366,9 +366,9 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void CanDiscardModifiedProject_AnswerNo_NotSavedAndReturnsTrue()
         {
-            var sut = CreateSut(out var messageBox, out var fileSystem);
+            var sut = CreateSut(out var dialogs, out IFileSystem fileSystem);
             sut.ProjectData.IsModified = true;
-            messageBox.ShowMessageBox(
+            dialogs.ShowMessageBox(
                     Arg.Any<string>(), Arg.Any<string>(),
                     Arg.Any<MessageBoxButton>(), Arg.Any<MessageBoxImage>(),
                     Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
@@ -377,7 +377,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
 
             sut.ProjectData.CanDiscardModifiedProject().Should().BeTrue();
 
-            messageBox.Received(1).ShowMessageBox(
+            dialogs.Received(1).ShowMessageBox(
                 Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<MessageBoxButton>(), Arg.Any<MessageBoxImage>(),
                 Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>());
@@ -387,7 +387,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public void CanDiscardModifiedProject_AnswerYes_SavedAndReturnsTrue()
         {
-            var sut = CreateSut(out var messageBox, out var fileSystem);
+            var sut = CreateSut(out var messageBox, out IFileSystem fileSystem);
             sut.ProjectData.IsModified = true;
             messageBox.ShowMessageBox(
                     Arg.Any<string>(), Arg.Any<string>(),
@@ -440,8 +440,8 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [CulturedFact("en")]
         public async Task LoadProjectFromFileAsync_UserWantsAutoSaveFile_AutoSaveFileLoaded()
         {
-            var sut = CreateSut(out var messageBox, out var fileSystem);
-            messageBox.ShowMessageBox(
+            var sut = CreateSut(out var dialogs, out IFileSystem fileSystem);
+            dialogs.ShowMessageBox(
                     Arg.Is<string>(s => s.Contains("automatically created backup file")), Arg.Any<string>(),
                     MessageBoxButton.YesNo, MessageBoxImage.Question,
                     Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
@@ -465,8 +465,8 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [CulturedFact("en")]
         public async Task LoadProjectFromFileAsync_UserDoesNotWantAutoSaveFileExists_AutoSaveFileLoaded()
         {
-            var sut = CreateSut(out var messageBox, out var fileSystem);
-            messageBox.ShowMessageBox(
+            var sut = CreateSut(out var dialogs, out IFileSystem fileSystem);
+            dialogs.ShowMessageBox(
                     Arg.Is<string>(s => s.Contains("automatically created backup file")), Arg.Any<string>(),
                     MessageBoxButton.YesNo, MessageBoxImage.Question,
                     Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
@@ -491,7 +491,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [Fact]
         public async Task LoadProjectFromFileAsync_NewFileOnSecureDrive_StoreOpenedAndFileLoaded()
         {
-            var sut = CreateSut(out var messageBox, out var fileSystem);
+            var sut = CreateSut(out var dialogs, out IFileSystem fileSystem);
             fileSystem.FileExists(Arg.Is("K:\\the.fileName")).Returns(true);
             fileSystem.ReadAllTextFromFile(Arg.Any<string>()).Returns(new AccountingData().Serialize());
             fileSystem.GetDrives().Returns(
@@ -507,7 +507,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
                 .Which.Should().Be(OperationResult.Completed);
 
             sut.ProjectData.Settings.SecuredDrives.Should().Equal(new object[] { "K:\\" });
-            messageBox.DidNotReceive().ShowMessageBox(
+            dialogs.DidNotReceive().ShowMessageBox(
                 Arg.Is<string>(s => s.Contains("Cryptomator")),
                 Arg.Any<string>(),
                 Arg.Any<MessageBoxButton>(), Arg.Any<MessageBoxImage>(),
@@ -564,10 +564,10 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
         [CulturedFact("en")]
         public async Task LoadProjectFromFileAsync_UserDoesNotWantSaveCurrentProject_LoadingAborted()
         {
-            var sut = CreateSut(out var messageBox, out var fileSystem);
+            var sut = CreateSut(out var dialogs, out IFileSystem fileSystem);
             sut.ProjectData.FileName = "old.fileName";
             sut.ProjectData.IsModified = true;
-            messageBox.ShowMessageBox(
+            dialogs.ShowMessageBox(
                     Arg.Is<string>(s => s.Contains("Project data has been changed.")), Arg.Any<string>(),
                     MessageBoxButton.YesNo, MessageBoxImage.Question,
                     Arg.Any<MessageBoxResult>(), Arg.Any<MessageBoxOptions>())
@@ -727,13 +727,13 @@ namespace lg2de.SimpleAccounting.UnitTests.Presentation
             return sut;
         }
 
-        private static ShellViewModel CreateSut(out IApplicationUpdate applicationUpdate)
+        private static ShellViewModel CreateSut(out IApplicationUpdate applicationUpdate, out IDialogs dialogs)
         {
             var busy = Substitute.For<IBusy>();
             var windowManager = Substitute.For<IWindowManager>();
             var reportFactory = Substitute.For<IReportFactory>();
             applicationUpdate = Substitute.For<IApplicationUpdate>();
-            var dialogs = Substitute.For<IDialogs>();
+            dialogs = Substitute.For<IDialogs>();
             var fileSystem = Substitute.For<IFileSystem>();
             var processApi = Substitute.For<IProcess>();
             var settings = new Settings();


### PR DESCRIPTION
## Description
Faced failed update from 2.0.0 to 2.1.0 with just short flashing powershell window.
This is an attempt to "fix" the problem with getting more details

## Related issue
Fixes #113
