### PR TITLE
Fix identification when editing entries with duplicated booking number

### DIFF
--- a/src/SimpleAccounting/Model/AccountingData.Extensions.cs
+++ b/src/SimpleAccounting/Model/AccountingData.Extensions.cs
@@ -304,6 +304,15 @@ namespace lg2de.SimpleAccounting.Model
 
     public partial class AccountingDataJournalBooking
     {
+        public long UniqueId
+        {
+            get
+            {
+                var singleBooking = this.Credit.Count == 1 ? this.Credit[0] : this.Debit[0];
+                return ((long)(this.ID.GetHashCode()) << 32) + singleBooking.Text.GetHashCode();
+            }
+        }
+
         internal IReadOnlyCollection<ulong> GetAccounts()
         {
             return this

--- a/src/SimpleAccounting/Model/AccountingData.Extensions.cs
+++ b/src/SimpleAccounting/Model/AccountingData.Extensions.cs
@@ -304,15 +304,6 @@ namespace lg2de.SimpleAccounting.Model
 
     public partial class AccountingDataJournalBooking
     {
-        public long UniqueId
-        {
-            get
-            {
-                var singleBooking = this.Credit.Count == 1 ? this.Credit[0] : this.Debit[0];
-                return ((long)(this.ID.GetHashCode()) << 32) + singleBooking.Text.GetHashCode();
-            }
-        }
-
         internal IReadOnlyCollection<ulong> GetAccounts()
         {
             return this

--- a/src/SimpleAccounting/Model/IProjectData.cs
+++ b/src/SimpleAccounting/Model/IProjectData.cs
@@ -8,6 +8,7 @@ namespace lg2de.SimpleAccounting.Model
     using System.Threading;
     using System.Threading.Tasks;
     using lg2de.SimpleAccounting.Infrastructure;
+    using lg2de.SimpleAccounting.Presentation;
     using lg2de.SimpleAccounting.Properties;
 
     /// <summary>
@@ -53,7 +54,7 @@ namespace lg2de.SimpleAccounting.Model
 
         void ShowAddBookingDialog(bool showInactiveAccounts);
 
-        void ShowEditBookingDialog(ulong bookingId, bool showInactiveAccounts);
+        void ShowEditBookingDialog(IJournalItem item, bool showInactiveAccounts);
 
         void ShowImportDialog();
 

--- a/src/SimpleAccounting/Model/ProjectData.cs
+++ b/src/SimpleAccounting/Model/ProjectData.cs
@@ -233,15 +233,13 @@ namespace lg2de.SimpleAccounting.Model
 
         public void ShowEditBookingDialog(IJournalItem item, bool showInactiveAccounts)
         {
-            var uniqueId = item.UniqueId;
-            var journalIndex = this.CurrentYear.Booking.FindIndex(x => x.UniqueId == uniqueId);
-            if (journalIndex < 0)
+            if (item.StorageIndex < 0)
             {
                 // summary item selected => ignore
                 return;
             }
 
-            var journalEntry = this.CurrentYear.Booking[journalIndex];
+            var journalEntry = this.CurrentYear.Booking[item.StorageIndex];
 
             var bookingModel = new EditBookingViewModel(
                 this,
@@ -289,7 +287,7 @@ namespace lg2de.SimpleAccounting.Model
 
             // replace entry
             journalEntry = bookingModel.CreateJournalEntry();
-            this.CurrentYear.Booking[journalIndex] = journalEntry;
+            this.CurrentYear.Booking[item.StorageIndex] = journalEntry;
 
             this.IsModified = true;
 

--- a/src/SimpleAccounting/Model/ProjectData.cs
+++ b/src/SimpleAccounting/Model/ProjectData.cs
@@ -231,9 +231,10 @@ namespace lg2de.SimpleAccounting.Model
             this.windowManager.ShowDialog(bookingModel);
         }
 
-        public void ShowEditBookingDialog(ulong bookingId, bool showInactiveAccounts)
+        public void ShowEditBookingDialog(IJournalItem item, bool showInactiveAccounts)
         {
-            var journalIndex = this.CurrentYear.Booking.FindIndex(x => x.ID == bookingId);
+            var uniqueId = item.UniqueId;
+            var journalIndex = this.CurrentYear.Booking.FindIndex(x => x.UniqueId == uniqueId);
             if (journalIndex < 0)
             {
                 // summary item selected => ignore

--- a/src/SimpleAccounting/Presentation/AccountJournalItemViewModel.cs
+++ b/src/SimpleAccounting/Presentation/AccountJournalItemViewModel.cs
@@ -9,6 +9,11 @@ namespace lg2de.SimpleAccounting.Presentation
     /// </summary>
     public class AccountJournalItemViewModel : JournalItemBaseViewModel
     {
+        public AccountJournalItemViewModel(int storageIndex)
+        {
+            this.StorageIndex = storageIndex;
+        }
+
         public double CreditValue { get; set; }
 
         public double DebitValue { get; set; }

--- a/src/SimpleAccounting/Presentation/AccountJournalViewModel.cs
+++ b/src/SimpleAccounting/Presentation/AccountJournalViewModel.cs
@@ -51,10 +51,11 @@ namespace lg2de.SimpleAccounting.Presentation
             double debitSum = 0;
             foreach (var booking in relevantBookings)
             {
+                var index = this.projectData.CurrentYear.Booking.IndexOf(booking);
                 var debitEntries = booking.Debit.Where(x => x.Account == accountNumber);
                 foreach (var debitEntry in debitEntries)
                 {
-                    var item = new AccountJournalItemViewModel
+                    var item = new AccountJournalItemViewModel(index)
                     {
                         Identifier = booking.ID,
                         Date = booking.Date.ToDateTime(),
@@ -72,7 +73,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 var creditEntries = booking.Credit.Where(x => x.Account == accountNumber);
                 foreach (var creditEntry in creditEntries)
                 {
-                    var item = new AccountJournalItemViewModel
+                    var item = new AccountJournalItemViewModel(index)
                     {
                         Identifier = booking.ID,
                         Date = booking.Date.ToDateTime(),
@@ -96,14 +97,14 @@ namespace lg2de.SimpleAccounting.Presentation
                 return;
             }
 
-            var sumItem = new AccountJournalItemViewModel();
+            var sumItem = new AccountJournalItemViewModel(0);
             this.Items.Add(sumItem);
             sumItem.IsSummary = true;
             sumItem.Text = Resources.Word_Total;
             sumItem.DebitValue = debitSum;
             sumItem.CreditValue = creditSum;
 
-            var balanceItem = new AccountJournalItemViewModel();
+            var balanceItem = new AccountJournalItemViewModel(0);
             this.Items.Add(balanceItem);
             balanceItem.IsSummary = true;
             balanceItem.Text = Resources.Word_Balance;

--- a/src/SimpleAccounting/Presentation/EditBookingAccountControl.xaml
+++ b/src/SimpleAccounting/Presentation/EditBookingAccountControl.xaml
@@ -65,18 +65,21 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
               </Grid.ColumnDefinitions>
-              <TextBox
+              <Border
                 Grid.Column="0"
-                Height="30"
-                Text="{Binding BookingText}"
-                ToolTip="{x:Static properties:Resources.Tooltip_SplitBookingValue}" />
+                BorderBrush="Red" BorderThickness="{Binding IsBookingTextErrorThickness}">
+                <TextBox
+                  Height="30"
+                  Text="{Binding BookingText, UpdateSourceTrigger=PropertyChanged}"
+                  ToolTip="{x:Static properties:Resources.Word_BookingText}" />
+              </Border>
               <local:NumberTextBox
                 Grid.Column="1"
                 Width="100" Height="30"
                 HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
                 Scale="2"
-                Text="{Binding BookingValue, StringFormat='#0.00'}"
-                ToolTip="{x:Static properties:Resources.Word_BookingText}" />
+                Text="{Binding BookingValue, StringFormat='#0.00', UpdateSourceTrigger=PropertyChanged}"
+                ToolTip="{x:Static properties:Resources.Tooltip_SplitBookingValue}" />
             </Grid>
             <local:NumberTextBox
               Grid.Column="0" Grid.Row="1"

--- a/src/SimpleAccounting/Presentation/FullJournalItemViewModel.cs
+++ b/src/SimpleAccounting/Presentation/FullJournalItemViewModel.cs
@@ -9,6 +9,11 @@ namespace lg2de.SimpleAccounting.Presentation
     /// </summary>
     public class FullJournalItemViewModel : JournalItemBaseViewModel
     {
+        public FullJournalItemViewModel(int storageIndex)
+        {
+            this.StorageIndex = storageIndex;
+        }
+
         public double Value { get; set; }
 
         public string CreditAccount { get; set; } = string.Empty;

--- a/src/SimpleAccounting/Presentation/FullJournalViewModel.cs
+++ b/src/SimpleAccounting/Presentation/FullJournalViewModel.cs
@@ -45,9 +45,11 @@ namespace lg2de.SimpleAccounting.Presentation
                 .ThenBy(b => b.ID);
             foreach (var booking in bookings)
             {
-                var item = new FullJournalItemViewModel
+                var index = this.projectData.CurrentYear.Booking.IndexOf(booking);
+                var item = new FullJournalItemViewModel(index)
                 {
-                    Date = booking.Date.ToDateTime(), Identifier = booking.ID, IsFollowup = booking.Followup
+                    Identifier = booking.ID,
+                    Date = booking.Date.ToDateTime(), IsFollowup = booking.Followup
                 };
                 var debitAccounts = booking.Debit;
                 var creditAccounts = booking.Credit;

--- a/src/SimpleAccounting/Presentation/IJournalItem.cs
+++ b/src/SimpleAccounting/Presentation/IJournalItem.cs
@@ -9,6 +9,6 @@ namespace lg2de.SimpleAccounting.Presentation
     /// </summary>
     public interface IJournalItem
     {
-        long UniqueId { get; }
+        int StorageIndex { get; }
     }
 }

--- a/src/SimpleAccounting/Presentation/IJournalItem.cs
+++ b/src/SimpleAccounting/Presentation/IJournalItem.cs
@@ -9,6 +9,6 @@ namespace lg2de.SimpleAccounting.Presentation
     /// </summary>
     public interface IJournalItem
     {
-        ulong Identifier { get; }
+        long UniqueId { get; }
     }
 }

--- a/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
+++ b/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
@@ -41,6 +41,6 @@ namespace lg2de.SimpleAccounting.Presentation
             }
         }
 
-        public long UniqueId => ((long)(this.Identifier.GetHashCode()) << 32) + this.Text.GetHashCode();
+        public int StorageIndex { get; protected set; } = -1;
     }
 }

--- a/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
+++ b/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
@@ -40,5 +40,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 this.NotifyOfPropertyChange();
             }
         }
+
+        public long UniqueId => ((long)(this.Identifier.GetHashCode()) << 32) + this.Text.GetHashCode();
     }
 }

--- a/src/SimpleAccounting/Presentation/MenuViewModel.cs
+++ b/src/SimpleAccounting/Presentation/MenuViewModel.cs
@@ -201,7 +201,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 return;
             }
 
-            this.projectData.ShowEditBookingDialog(journalItem.Identifier, this.projectData.ShowInactiveAccounts);
+            this.projectData.ShowEditBookingDialog(journalItem, this.projectData.ShowInactiveAccounts);
         }
 
         private void OnCloseYear(object _)

--- a/src/SimpleAccounting/Presentation/ShellDesignViewModel.cs
+++ b/src/SimpleAccounting/Presentation/ShellDesignViewModel.cs
@@ -62,7 +62,8 @@ namespace lg2de.SimpleAccounting.Presentation
 
         private void LoadJournal()
         {
-            var journalItem = new FullJournalItemViewModel
+            int index = 0;
+            var journalItem = new FullJournalItemViewModel(index++)
             {
                 Identifier = 41,
                 Date = DateTime.Now,
@@ -72,7 +73,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 DebitAccount = "400"
             };
             this.FullJournal.Items.Add(journalItem);
-            journalItem = new FullJournalItemViewModel
+            journalItem = new FullJournalItemViewModel(index++)
             {
                 Identifier = 42,
                 Date = DateTime.Now,
@@ -83,7 +84,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 IsFollowup = true
             };
             this.FullJournal.Items.Add(journalItem);
-            journalItem = new FullJournalItemViewModel
+            journalItem = new FullJournalItemViewModel(index++)
             {
                 Identifier = 43,
                 Date = DateTime.Now,
@@ -93,7 +94,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 DebitAccount = "401",
             };
             this.FullJournal.Items.Add(journalItem);
-            journalItem = new FullJournalItemViewModel
+            journalItem = new FullJournalItemViewModel(index)
             {
                 Identifier = 44,
                 Date = DateTime.Now,
@@ -105,7 +106,8 @@ namespace lg2de.SimpleAccounting.Presentation
             this.FullJournal.Items.Add(journalItem);
             this.FullJournal.Items.UpdateRowHighlighting();
 
-            var accountJournalItem = new AccountJournalItemViewModel
+            index = 0;
+            var accountJournalItem = new AccountJournalItemViewModel(index++)
             {
                 Identifier = 42,
                 Date = DateTime.Now,
@@ -114,7 +116,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 RemoteAccount = "Div."
             };
             this.AccountJournal.Items.Add(accountJournalItem);
-            accountJournalItem = new AccountJournalItemViewModel
+            accountJournalItem = new AccountJournalItemViewModel(index++)
             {
                 Identifier = 44,
                 Date = DateTime.Now,
@@ -123,7 +125,7 @@ namespace lg2de.SimpleAccounting.Presentation
                 RemoteAccount = "Div."
             };
             this.AccountJournal.Items.Add(accountJournalItem);
-            accountJournalItem = new AccountJournalItemViewModel
+            accountJournalItem = new AccountJournalItemViewModel(index)
             {
                 IsSummary = true, Text = "Summe", CreditValue = 123.4, RemoteAccount = "Div."
             };

--- a/src/SimpleAccounting/Presentation/SplitBookingViewModel.cs
+++ b/src/SimpleAccounting/Presentation/SplitBookingViewModel.cs
@@ -9,6 +9,7 @@ namespace lg2de.SimpleAccounting.Presentation
     public class SplitBookingViewModel : Screen
     {
         private ulong accountNumber;
+        private string bookingText = string.Empty;
 
         public ulong AccountNumber
         {
@@ -27,8 +28,24 @@ namespace lg2de.SimpleAccounting.Presentation
 
         public int AccountIndex { get; set; } = -1;
 
-        public string BookingText { get; set; } = string.Empty;
+        public string BookingText
+        {
+            get => this.bookingText;
+            set
+            {
+                if (value == this.bookingText)
+                {
+                    return;
+                }
+
+                this.bookingText = value;
+                this.NotifyOfPropertyChange();
+                this.NotifyOfPropertyChange(nameof(this.IsBookingTextErrorThickness));
+            }
+        }
 
         public double BookingValue { get; set; }
+
+        public int IsBookingTextErrorThickness => string.IsNullOrWhiteSpace(this.BookingText) ? 1 : 0;
     }
 }

--- a/tests/SimpleAccounting.UnitTests/Presentation/SplitBookingViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/SplitBookingViewModelTests.cs
@@ -1,0 +1,53 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.UnitTests.Presentation
+{
+    using FluentAssertions;
+    using lg2de.SimpleAccounting.Presentation;
+    using Xunit;
+
+    public class SplitBookingViewModelTests
+    {
+        [Fact]
+        public void IsBookingTextErrorThickness_BlankText_ErrorShown()
+        {
+            var sut = new SplitBookingViewModel { BookingText = " " };
+
+            sut.IsBookingTextErrorThickness.Should().Be(1);
+        }
+        
+        [Fact]
+        public void IsBookingTextErrorThickness_ValueText_ErrorHidden()
+        {
+            var sut = new SplitBookingViewModel { BookingText = "X" };
+
+            sut.IsBookingTextErrorThickness.Should().Be(0);
+        }
+
+        [Fact]
+        public void IsBookingTextErrorThickness_BlankTextRemoved_ErrorDisappears()
+        {
+            var sut = new SplitBookingViewModel { BookingText = " " };
+            using var monitor = sut.Monitor();
+
+            sut.BookingText = "X";
+            
+            sut.IsBookingTextErrorThickness.Should().Be(0);
+            monitor.Should().RaisePropertyChangeFor(x => x.IsBookingTextErrorThickness);
+        }
+
+        [Fact]
+        public void IsBookingTextErrorThickness_TextRemoved_ErrorAppears()
+        {
+            var sut = new SplitBookingViewModel { BookingText = "X" };
+            using var monitor = sut.Monitor();
+
+            sut.BookingText = " ";
+            
+            sut.IsBookingTextErrorThickness.Should().Be(1);
+            monitor.Should().RaisePropertyChangeFor(x => x.IsBookingTextErrorThickness);
+        }
+    }
+}


### PR DESCRIPTION
## Description
If (at least) two entries exists with same booking number, and the second is double-clicked, the first one is opened for editing.
