### PR TITLE
Add booking year name to page header of journal reports

### DIFF
--- a/src/SimpleAccounting/Reports/AccountJournal.xml
+++ b/src/SimpleAccounting/Reports/AccountJournal.xml
@@ -3,8 +3,8 @@
 <xEport paperSize="A4" left="20" top="15" bottom="15" right="20">
   <pageTexts>
     <font size="8">
-      <text absX="85" absY="-5" align="center">- @Header_AccountSheets@ -</text>
-      <text absX="85" absY="270" align="center">- @Word_Page@ {page} -</text>
+      <text absX="85" absY="-5" align="center">- @Header_AccountSheets@ {yearName} -</text>
+      <text absX="85" absY="270" align="center">- @Word_Page@ {pageNumber} -</text>
     </font>
   </pageTexts>
   <font size="20" />

--- a/src/SimpleAccounting/Reports/AccountJournalReport.cs
+++ b/src/SimpleAccounting/Reports/AccountJournalReport.cs
@@ -22,8 +22,8 @@ namespace lg2de.SimpleAccounting.Reports
         private double debitTotal;
         private bool firstAccount;
 
-        public AccountJournalReport(IProjectData projectData)
-            : base(ResourceName, projectData)
+        public AccountJournalReport(IXmlPrinter printer, IProjectData projectData)
+            : base(printer, ResourceName, projectData)
         {
             this.accounts = projectData.Storage.AllAccounts.OrderBy(a => a.ID);
         }
@@ -35,7 +35,7 @@ namespace lg2de.SimpleAccounting.Reports
 
         public void CreateReport(string title)
         {
-            this.PreparePrintDocument(title);
+            this.PreparePrintDocument(title, DateTime.Now);
 
             XmlNode tableNode = this.PrintDocument.SelectSingleNode("//table");
 

--- a/src/SimpleAccounting/Reports/AnnualBalance.xml
+++ b/src/SimpleAccounting/Reports/AnnualBalance.xml
@@ -2,12 +2,12 @@
 <!-- Copyright (c) Lukas Grützmacher. All rights reserved. -->
 <xEport paperSize="A4" left="20" top="15" bottom="15" right="20">
   <font size="20" />
-  <text absX="85" align="center">@Header_AnnualBalance@</text>
+  <text absX="85" align="center">- @Header_AnnualBalance@ -</text>
   <move relY="10" />
   <font size="10" />
   <text ID="firm" absX="85" align="center">-Firm-</text>
   <move relY="5" />
-  <text ID="yearName" absX="85" align="center">-Year-</text>
+  <text absX="85" align="center">{yearName}</text>
   <move relY="10" />
   <font size="8" />
   <table lineHeight="4">

--- a/src/SimpleAccounting/Reports/AnnualBalanceReport.cs
+++ b/src/SimpleAccounting/Reports/AnnualBalanceReport.cs
@@ -4,6 +4,7 @@
 
 namespace lg2de.SimpleAccounting.Reports
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
@@ -21,15 +22,15 @@ namespace lg2de.SimpleAccounting.Reports
 
         private readonly List<AccountDefinition> allAccounts;
 
-        public AnnualBalanceReport(IProjectData projectData)
-            : base(ResourceName, projectData)
+        public AnnualBalanceReport(IXmlPrinter printer, IProjectData projectData)
+            : base(printer, ResourceName, projectData)
         {
             this.allAccounts = projectData.Storage.AllAccounts.ToList();
         }
 
         public void CreateReport(string title)
         {
-            this.PreparePrintDocument(title);
+            this.PreparePrintDocument(title, DateTime.Now);
 
             // income / Einnahmen
             this.ProcessIncome(out var totalIncome);

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -20,15 +20,16 @@ namespace lg2de.SimpleAccounting.Reports
         protected const int TitleSize = 10;
         private readonly AccountingDataSetup setup;
 
-        protected ReportBase(string resourceName, IProjectData projectData)
+        protected ReportBase(IXmlPrinter printer, string resourceName, IProjectData projectData)
         {
+            this.Printer = printer;
             this.setup = projectData.Storage.Setup;
             this.YearData = projectData.CurrentYear;
 
             this.Printer.LoadDocument(resourceName);
         }
 
-        protected IXmlPrinter Printer { get; set; } = new XmlPrinter();
+        protected IXmlPrinter Printer { get; }
 
         protected AccountingDataJournal YearData { get; }
 
@@ -43,7 +44,7 @@ namespace lg2de.SimpleAccounting.Reports
             this.Printer.PrintDocument($"{this.PrintingDate:yyyy-MM-dd} {documentName} {this.YearData.Year}");
         }
 
-        protected void PreparePrintDocument(string title)
+        protected void PreparePrintDocument(string title, DateTime printDate)
         {
             var textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"title\"]");
             if (textNode != null)
@@ -58,7 +59,10 @@ namespace lg2de.SimpleAccounting.Reports
             }
 
             textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"firm\"]");
-            textNode.InnerText = this.setup?.Name;
+            if (textNode != null)
+            {
+                textNode.InnerText = this.setup?.Name;
+            }
 
             var elements = this.PrintDocument.SelectNodes("//*[contains(text(),'yearName')]")!;
             foreach (var element in elements.OfType<XmlElement>())
@@ -76,7 +80,11 @@ namespace lg2de.SimpleAccounting.Reports
             }
 
             textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"date\"]");
-            textNode.InnerText = this.setup?.Location + ", " + DateTime.Now.ToString("D", CultureInfo.CurrentCulture);
+            if (textNode != null)
+            {
+                textNode.InnerText =
+                    this.setup?.Location + ", " + printDate.ToString("D", CultureInfo.CurrentCulture);
+            }
         }
     }
 }

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -6,6 +6,7 @@ namespace lg2de.SimpleAccounting.Reports
 {
     using System;
     using System.Globalization;
+    using System.Linq;
     using System.Xml;
     using System.Xml.Linq;
     using lg2de.SimpleAccounting.Extensions;
@@ -59,10 +60,11 @@ namespace lg2de.SimpleAccounting.Reports
             textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"firm\"]");
             textNode.InnerText = this.setup?.Name;
 
-            textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"yearName\"]");
-            if (textNode != null)
+            var elements = this.PrintDocument.SelectNodes("//*[contains(text(),'yearName')]")!;
+            foreach (var element in elements.OfType<XmlElement>())
             {
-                textNode.InnerText = this.YearData.Year;
+                element.InnerText = element.InnerText.Replace(
+                    "{yearName}", this.YearData.Year, StringComparison.InvariantCultureIgnoreCase);
             }
 
             textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"range\"]");

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -18,30 +18,30 @@ namespace lg2de.SimpleAccounting.Reports
     internal class ReportBase
     {
         protected const int TitleSize = 10;
+
+        private readonly IXmlPrinter printer;
         private readonly AccountingDataSetup setup;
 
         protected ReportBase(IXmlPrinter printer, string resourceName, IProjectData projectData)
         {
-            this.Printer = printer;
+            this.printer = printer;
             this.setup = projectData.Storage.Setup;
             this.YearData = projectData.CurrentYear;
 
-            this.Printer.LoadDocument(resourceName);
+            this.printer.LoadDocument(resourceName);
         }
-
-        protected IXmlPrinter Printer { get; }
 
         protected AccountingDataJournal YearData { get; }
 
         protected DateTime PrintingDate { get; set; } = DateTime.Now;
 
-        protected XmlDocument PrintDocument => this.Printer.Document;
+        protected XmlDocument PrintDocument => this.printer.Document;
 
-        internal XDocument DocumentForTests => XDocument.Parse(this.Printer.Document.OuterXml);
+        internal XDocument DocumentForTests => XDocument.Parse(this.printer.Document.OuterXml);
 
         public void ShowPreview(string documentName)
         {
-            this.Printer.PrintDocument($"{this.PrintingDate:yyyy-MM-dd} {documentName} {this.YearData.Year}");
+            this.printer.PrintDocument($"{this.PrintingDate:yyyy-MM-dd} {documentName} {this.YearData.Year}");
         }
 
         protected void PreparePrintDocument(string title, DateTime printDate)
@@ -61,7 +61,7 @@ namespace lg2de.SimpleAccounting.Reports
             textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"firm\"]");
             if (textNode != null)
             {
-                textNode.InnerText = this.setup?.Name;
+                textNode.InnerText = this.setup.Name;
             }
 
             var elements = this.PrintDocument.SelectNodes("//*[contains(text(),'yearName')]")!;
@@ -83,7 +83,7 @@ namespace lg2de.SimpleAccounting.Reports
             if (textNode != null)
             {
                 textNode.InnerText =
-                    this.setup?.Location + ", " + printDate.ToString("D", CultureInfo.CurrentCulture);
+                    this.setup.Location + ", " + printDate.ToString("D", CultureInfo.CurrentCulture);
             }
         }
     }

--- a/src/SimpleAccounting/Reports/ReportFactory.cs
+++ b/src/SimpleAccounting/Reports/ReportFactory.cs
@@ -16,24 +16,24 @@ namespace lg2de.SimpleAccounting.Reports
     {
         public IAccountJournalReport CreateAccountJournal(IProjectData projectData)
         {
-            return new AccountJournalReport(projectData);
+            return new AccountJournalReport(new XmlPrinter(), projectData);
         }
 
         public ITotalJournalReport CreateTotalJournal(IProjectData projectData)
         {
-            return new TotalJournalReport(projectData);
+            return new TotalJournalReport(new XmlPrinter(), projectData);
         }
 
         public IAnnualBalanceReport CreateAnnualBalance(IProjectData projectData)
         {
-            return new AnnualBalanceReport(projectData);
+            return new AnnualBalanceReport(new XmlPrinter(), projectData);
         }
 
         public ITotalsAndBalancesReport CreateTotalsAndBalances(
             IProjectData projectData,
             IEnumerable<AccountingDataAccountGroup> accounts)
         {
-            return new TotalsAndBalancesReport(projectData, accounts);
+            return new TotalsAndBalancesReport(new XmlPrinter(), projectData, accounts);
         }
     }
 }

--- a/src/SimpleAccounting/Reports/TotalJournal.xml
+++ b/src/SimpleAccounting/Reports/TotalJournal.xml
@@ -3,8 +3,8 @@
 <xEport paperSize="A4" left="20" top="15" bottom="15" right="20">
   <pageTexts>
     <font size="8">
-      <text absX="85" absY="-5" align="center">- @Header_Journal@ -</text>
-      <text absX="85" absY="270" align="center">- @Word_Page@ {page} -</text>
+      <text absX="85" absY="-5" align="center">- @Header_Journal@ {yearName} -</text>
+      <text absX="85" absY="270" align="center">- @Word_Page@ {pageNumber} -</text>
     </font>
   </pageTexts>
   <font size="20" />

--- a/src/SimpleAccounting/Reports/TotalJournalReport.cs
+++ b/src/SimpleAccounting/Reports/TotalJournalReport.cs
@@ -4,6 +4,7 @@
 
 namespace lg2de.SimpleAccounting.Reports
 {
+    using System;
     using System.Globalization;
     using System.Linq;
     using System.Xml;
@@ -17,14 +18,14 @@ namespace lg2de.SimpleAccounting.Reports
     {
         public const string ResourceName = "TotalJournal.xml";
 
-        public TotalJournalReport(IProjectData projectData)
-            : base(ResourceName, projectData)
+        public TotalJournalReport(IXmlPrinter printer, IProjectData projectData)
+            : base(printer, ResourceName, projectData)
         {
         }
 
         public void CreateReport(string title)
         {
-            this.PreparePrintDocument(title);
+            this.PreparePrintDocument(title, DateTime.Now);
 
             XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data");
 

--- a/src/SimpleAccounting/Reports/TotalsAndBalances.xml
+++ b/src/SimpleAccounting/Reports/TotalsAndBalances.xml
@@ -4,7 +4,7 @@
   <pageTexts>
     <font size="8">
       <text ID="pageTitle" absX="135" absY="-5" align="center">- @Header_TotalsAndBalances@ -</text>
-      <text absX="135" absY="180" align="center">- @Word_Page@ {page} -</text>
+      <text absX="135" absY="180" align="center">- @Word_Page@ {pageNumber} -</text>
     </font>
   </pageTexts>
   <font size="20" />

--- a/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
+++ b/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
@@ -4,6 +4,7 @@
 
 namespace lg2de.SimpleAccounting.Reports
 {
+    using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
@@ -39,9 +40,10 @@ namespace lg2de.SimpleAccounting.Reports
         ///     This is an overview over all accounts with totals and balances, grouped by account groups.
         /// </remarks>
         public TotalsAndBalancesReport(
+            IXmlPrinter printer,
             IProjectData projectData,
             IEnumerable<AccountingDataAccountGroup> accountGroups)
-            : base(ResourceName, projectData)
+            : base(printer, ResourceName, projectData)
         {
             this.accountGroups = accountGroups.ToList();
         }
@@ -50,7 +52,7 @@ namespace lg2de.SimpleAccounting.Reports
 
         public void CreateReport(string title)
         {
-            this.PreparePrintDocument(title);
+            this.PreparePrintDocument(title, DateTime.Now);
 
             XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data");
 

--- a/src/SimpleAccounting/Reports/XmlPrinter.cs
+++ b/src/SimpleAccounting/Reports/XmlPrinter.cs
@@ -616,7 +616,7 @@ namespace lg2de.SimpleAccounting.Reports
                 foreach (var element in textElements.OfType<XmlElement>())
                 {
                     element.InnerText = element.InnerText.Replace(
-                        "{page}", pageNumberText, StringComparison.InvariantCultureIgnoreCase);
+                        "{pageNumber}", pageNumberText, StringComparison.InvariantCultureIgnoreCase);
                 }
 
                 insertParent.ParentNode!.InsertAfter(copiedChild, insertParent);

--- a/tests/SimpleAccounting.UnitTests/Reports/AccountJournalReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/AccountJournalReportTests.cs
@@ -26,7 +26,10 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
         {
             var projectData = Samples.SampleProjectData;
             projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-            var sut = new AccountJournalReport(projectData) { PageBreakBetweenAccounts = pageBreakBetweenAccounts };
+            var sut = new AccountJournalReport(new XmlPrinter(), projectData)
+            {
+                PageBreakBetweenAccounts = pageBreakBetweenAccounts
+            };
 
             sut.CreateReport("dummy");
 

--- a/tests/SimpleAccounting.UnitTests/Reports/AnnualBalanceReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/AnnualBalanceReportTests.cs
@@ -19,7 +19,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
         {
             var projectData = Samples.SampleProjectData;
             projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-            var sut = new AnnualBalanceReport(projectData);
+            var sut = new AnnualBalanceReport(new XmlPrinter(), projectData);
 
             sut.CreateReport("dummy");
 

--- a/tests/SimpleAccounting.UnitTests/Reports/ReportBaseTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/ReportBaseTests.cs
@@ -6,6 +6,8 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
 {
     using System;
     using System.Linq;
+    using System.Xml;
+    using FluentAssertions;
     using lg2de.SimpleAccounting.Model;
     using lg2de.SimpleAccounting.Reports;
     using lg2de.SimpleAccounting.UnitTests.Presentation;
@@ -16,30 +18,78 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
     {
         private class TestReport : ReportBase
         {
-            public TestReport(ProjectData projectData)
-                : base(AnnualBalanceReport.ResourceName, projectData)
+            public TestReport(IXmlPrinter printer, ProjectData projectData)
+                : base(printer, string.Empty, projectData)
             {
-                this.Printer = this.TestingPrinter = Substitute.For<IXmlPrinter>();
             }
 
-            public IXmlPrinter TestingPrinter { get; }
+            public new XmlDocument PrintDocument => base.PrintDocument;
 
             public void SetPrintingDate(DateTime dateTime)
             {
                 this.PrintingDate = dateTime;
             }
+
+            public new void PreparePrintDocument(string title, DateTime printDate)
+            {
+                base.PreparePrintDocument(title, printDate);
+            }
+        }
+
+        [Fact]
+        public void PreparePrintDocument_EmptyXml_Completed()
+        {
+            var printer = Substitute.For<IXmlPrinter>();
+            printer.Document.Returns(new XmlDocument());
+            var sut = new TestReport(printer, Samples.SampleProjectData);
+
+            sut.Invoking(x => x.PreparePrintDocument("TheTitle", DateTime.Now)).Should().NotThrow();
+        }
+
+        [CulturedFact("en")]
+        public void PreparePrintDocument_SampleXml_PlaceholdersUpdates()
+        {
+            var printer = Substitute.For<IXmlPrinter>();
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml(
+                @"
+<root>
+  <text ID=""title"">XXX</text>
+  <text ID=""pageTitle"">XXX</text>
+  <text ID=""firm"">XXX</text>
+  <text>- {yearName} -</text>
+  <text ID=""range"">XXX</text>
+  <text ID=""date"">XXX</text>
+</root>");
+            printer.Document.Returns(xmlDocument);
+            var projectData = Samples.SampleProjectData;
+            projectData.Storage.Setup.Name = "TheName";
+            projectData.Storage.Setup.Location = "TheLocation";
+            projectData.SelectYear(projectData.Storage.Journal.First().Year);
+            var sut = new TestReport(printer, projectData);
+
+            sut.PreparePrintDocument("TheTitle", new DateTime(2021, 5, 5));
+
+            sut.PrintDocument.OuterXml.Should().Be(
+                "<root><text ID=\"title\">TheTitle</text>"
+                + "<text ID=\"pageTitle\">- TheTitle -</text>"
+                + "<text ID=\"firm\">TheName</text>"
+                + "<text>- 2000 -</text>"
+                + "<text ID=\"range\">1/1/2000 - 12/31/2000</text>"
+                + "<text ID=\"date\">TheLocation, Wednesday, May 5, 2021</text></root>");
         }
 
         [Fact]
         public void ShowPreview_DocumentName_PrintingNameCorrect()
         {
-            var sut = new TestReport(Samples.SampleProjectData);
+            var printer = Substitute.For<IXmlPrinter>();
+            var sut = new TestReport(printer, Samples.SampleProjectData);
             sut.SetPrintingDate(new DateTime(2020, 2, 29));
 
             sut.ShowPreview("DocumentName");
 
             var year = Samples.SampleProject.Journal.Last().Year;
-            sut.TestingPrinter.Received(1).PrintDocument($"2020-02-29 DocumentName {year}");
+            printer.Received(1).PrintDocument($"2020-02-29 DocumentName {year}");
         }
     }
 }

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalJournalReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalJournalReportTests.cs
@@ -19,7 +19,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
         {
             var projectData = Samples.SampleProjectData;
             projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-            var sut = new TotalJournalReport(projectData);
+            var sut = new TotalJournalReport(new XmlPrinter(), projectData);
 
             sut.CreateReport("dummy");
 

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
@@ -19,7 +19,8 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
         {
             var projectData = Samples.SampleProjectData;
             projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-            var sut = new TotalsAndBalancesReport(projectData, projectData.Storage.Accounts);
+            var sut = new TotalsAndBalancesReport(
+                new XmlPrinter(), projectData, projectData.Storage.Accounts);
 
             sut.CreateReport("dummy");
 
@@ -134,7 +135,8 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
         public void CreateReport_SampleWithSignature_SignatureLinesCreated()
         {
             var projectData = Samples.SampleProjectData;
-            var sut = new TotalsAndBalancesReport(projectData, projectData.Storage.Accounts);
+            var sut = new TotalsAndBalancesReport(
+                new XmlPrinter(), projectData, projectData.Storage.Accounts);
             sut.Signatures.Add("The Name");
 
             sut.CreateReport("dummy");

--- a/tests/SimpleAccounting.UnitTests/Reports/XmlPrinterTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/XmlPrinterTests.cs
@@ -489,7 +489,7 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports
             var sut = new XmlPrinter { DocumentHeight = 10 };
             sut.LoadXml(
                 "<root>"
-                + "<pageTexts><font><text>page {page}</text></font></pageTexts>"
+                + "<pageTexts><font><text>page {pageNumber}</text></font></pageTexts>"
                 + "<table><columns>"
                 + "<column width=\"10\">C1</column>"
                 + "</columns><data>"


### PR DESCRIPTION
## Description
The journal reports, account journal and total journal, may have many pages.
Then the report header, informing on booking year, may not be on the same page.
Therefore this PR adds year name to the page header of these reports.

Other report are quite short, only one or two pages.
The year name in the page header is nearly redundant.
So, I did not add it there.

## Related issue
Fixed #126.
