### PR TITLE
Update recent list immediately after loading and saving project

### DIFF
--- a/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
+++ b/src/SimpleAccounting/Infrastructure/ProjectFileLoader.cs
@@ -16,7 +16,6 @@ using lg2de.SimpleAccounting.Properties;
 
 internal class ProjectFileLoader
 {
-    private const int MaxRecentProjects = 10;
     private readonly IFileSystem fileSystem;
 
     private readonly IDialogs dialogs;
@@ -170,11 +169,6 @@ internal class ProjectFileLoader
             this.settings.SecuredDrives.Add(info.RootPath);
         }
 
-        this.settings.RecentProjects.Remove(projectFileName);
-        this.settings.RecentProjects.Insert(0, projectFileName);
-        while (this.settings.RecentProjects.Count > MaxRecentProjects)
-        {
-            this.settings.RecentProjects.RemoveAt(MaxRecentProjects);
-        }
+        this.settings.SetRecentProject(projectFileName);
     }
 }

--- a/src/SimpleAccounting/Model/ProjectData.cs
+++ b/src/SimpleAccounting/Model/ProjectData.cs
@@ -167,6 +167,8 @@ internal class ProjectData : IProjectData
         {
             this.fileSystem.FileDelete(this.AutoSaveFileName);
         }
+
+        this.Settings.SetRecentProject(this.FileName);
     }
 
     public async Task AutoSaveAsync(CancellationToken cancellationToken)

--- a/src/SimpleAccounting/Properties/Settings.Extensions.cs
+++ b/src/SimpleAccounting/Properties/Settings.Extensions.cs
@@ -4,15 +4,20 @@
 
 namespace lg2de.SimpleAccounting.Properties;
 
-using System.Collections.Specialized;
-
 internal sealed partial class Settings
 {
     private const int MaxRecentProjects = 10;
 
+    /// <summary>
+    ///     Sets the specified project file (path) as the most recent project. 
+    /// </summary>
+    /// <remarks>
+    ///     The list of recent projects is updated automatically.
+    /// </remarks>
+    /// <param name="projectFileName">The full path of the recent project.</param>
     public void SetRecentProject(string projectFileName)
     {
-        this.RecentProjects ??= new StringCollection();
+        this.RecentProjects ??= [];
         this.RecentProjects.Remove(projectFileName);
         this.RecentProjects.Insert(0, projectFileName);
         while (this.RecentProjects.Count > MaxRecentProjects)

--- a/src/SimpleAccounting/Properties/Settings.Extensions.cs
+++ b/src/SimpleAccounting/Properties/Settings.Extensions.cs
@@ -1,0 +1,23 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.Properties;
+
+using System.Collections.Specialized;
+
+internal sealed partial class Settings
+{
+    private const int MaxRecentProjects = 10;
+
+    public void SetRecentProject(string projectFileName)
+    {
+        this.RecentProjects ??= new StringCollection();
+        this.RecentProjects.Remove(projectFileName);
+        this.RecentProjects.Insert(0, projectFileName);
+        while (this.RecentProjects.Count > MaxRecentProjects)
+        {
+            this.RecentProjects.RemoveAt(MaxRecentProjects);
+        }
+    }
+}

--- a/tests/SimpleAccounting.UnitTests/Presentation/MenuViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/MenuViewModelTests.cs
@@ -82,6 +82,18 @@ public class MenuViewModelTests
     }
 
     [Fact]
+    public void RecentProjects_SaveNewFile_AddedToList()
+    {
+        var sut = CreateSut(out ProjectData projectData);
+        sut.NewProjectCommand.Execute(null);
+        projectData.FileName = "this-is-the-file-name";
+
+        sut.SaveProjectCommand.Execute(null);
+
+        sut.RecentProjects.Should().BeEquivalentTo(new[] { new { Header = "this-is-the-file-name" } });
+    }
+
+    [Fact]
     public void NewProjectCommand_ModifiedProjectNoDiscard_ProjectRemains()
     {
         MenuViewModel sut = CreateSut(out ProjectData projectData);
@@ -376,7 +388,8 @@ public class MenuViewModelTests
         return sut;
     }
 
-    private static MenuViewModel CreateSut(out ProjectData projectData, out IDialogs dialogs, out IReportFactory reportFactory)
+    private static MenuViewModel CreateSut(
+        out ProjectData projectData, out IDialogs dialogs, out IReportFactory reportFactory)
     {
         var windowManager = Substitute.For<IWindowManager>();
         var fileSystem = Substitute.For<IFileSystem>();

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -279,7 +279,7 @@ public partial class ShellViewModelTests
         ((IActivate)sut).Activate();
         sut.Menu.RecentProjects.Select(x => x.Header).Should().Equal("K:\\file1", "file2");
 
-        foreach (var viewModel in sut.Menu.RecentProjects)
+        foreach (var viewModel in sut.Menu.RecentProjects.ToList())
         {
             await viewModel.Command.ExecuteAsync(null);
         }


### PR DESCRIPTION
## Description
When loading a project, the recent list was updated internally, but not shown immediately.
When saving a project, the recent list was never updated.
These issues are fixed now.

## Related issue
Fixes #186 
