### PR TITLE
Fully hide date and identifier for account journal summary rows

### DIFF
--- a/src/SimpleAccounting/Presentation/DateConverter.cs
+++ b/src/SimpleAccounting/Presentation/DateConverter.cs
@@ -8,6 +8,9 @@ using System;
 using System.Globalization;
 using System.Windows.Data;
 
+/// <summary>
+///     Implements a converter for <see cref="DateTime"/> into date only supporting <langword>null</langword>.
+/// </summary>
 public class DateConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -15,7 +18,7 @@ public class DateConverter : IValueConverter
         const int firstYear = 1900;
         return value is not DateTime dateTime || dateTime.Year < firstYear
             ? null
-            : dateTime.ToString("d", CultureInfo.CurrentUICulture);
+            : dateTime.ToString("d", culture);
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/SimpleAccounting/Presentation/DateConverter.cs
+++ b/src/SimpleAccounting/Presentation/DateConverter.cs
@@ -1,0 +1,25 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.Presentation;
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+public class DateConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        const int firstYear = 1900;
+        return value is not DateTime dateTime || dateTime.Year < firstYear
+            ? null
+            : dateTime.ToString("d", CultureInfo.CurrentUICulture);
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
+++ b/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
@@ -7,6 +7,7 @@ namespace lg2de.SimpleAccounting.Presentation;
 using System;
 using System.Globalization;
 using Caliburn.Micro;
+using JetBrains.Annotations;
 
 /// <summary>
 ///     Implements the base view model for items in all journals.
@@ -32,7 +33,7 @@ public class JournalItemBaseViewModel : PropertyChangedBase, IJournalItem
 
     public bool IsEvenRow
     {
-        get => this.isEvenRow;
+        [UsedImplicitly] get => this.isEvenRow;
         set
         {
             if (value == this.isEvenRow)
@@ -45,5 +46,5 @@ public class JournalItemBaseViewModel : PropertyChangedBase, IJournalItem
         }
     }
 
-    public int StorageIndex { get; protected set; } = -1;
+    public int StorageIndex { get; protected init; } = -1;
 }

--- a/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
+++ b/src/SimpleAccounting/Presentation/JournalItemBaseViewModel.cs
@@ -5,6 +5,7 @@
 namespace lg2de.SimpleAccounting.Presentation;
 
 using System;
+using System.Globalization;
 using Caliburn.Micro;
 
 /// <summary>
@@ -19,6 +20,9 @@ public class JournalItemBaseViewModel : PropertyChangedBase, IJournalItem
     }
 
     public ulong Identifier { get; set; }
+
+    public string IdentifierText =>
+        this.Identifier > 0 ? this.Identifier.ToString(CultureInfo.InvariantCulture) : string.Empty;
 
     public DateTime Date { get; set; }
 

--- a/src/SimpleAccounting/Presentation/ShellView.xaml
+++ b/src/SimpleAccounting/Presentation/ShellView.xaml
@@ -16,6 +16,7 @@
       <Setter Property="FontSize" Value="15" />
       <Setter Property="Margin" Value="5" />
     </Style>
+    <local:DateConverter x:Key="DateConverter" />
   </Window.Resources>
   <Window.InputBindings>
     <KeyBinding Key="B" Modifiers="Control" Command="{Binding Menu.AddBookingsCommand}" />
@@ -202,10 +203,10 @@
             <DataGrid.Columns>
               <DataGridTextColumn
                 Header="{x:Static properties:Resources.Word_Date}" Width="60"
-                Binding="{Binding Date, StringFormat=\{0:d\}}"
+                Binding="{Binding Date, Converter={StaticResource DateConverter}}"
                 CellStyle="{StaticResource SummaryGridStyle}" />
               <DataGridTextColumn Header="{x:Static properties:Resources.Word_BookingNumber_Short}" Width="75"
-                                  Binding="{Binding Identifier}"
+                                  Binding="{Binding IdentifierText}"
                                   CellStyle="{StaticResource SummaryGridStyle}" />
               <DataGridTextColumn Header="{x:Static properties:Resources.Word_BookingText}" Width="200"
                                   Binding="{Binding Text}" />

--- a/tests/SimpleAccounting.UnitTests/Presentation/DateConverterTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/DateConverterTests.cs
@@ -1,0 +1,57 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.UnitTests.Presentation;
+
+using System;
+using System.Globalization;
+using FluentAssertions;
+using lg2de.SimpleAccounting.Presentation;
+using Xunit;
+
+public class DateConverterTests
+{
+    [Fact]
+    public void Convert_NullInput_NullReturned()
+    {
+        var sut = new DateConverter();
+
+        var result = sut.Convert(null, typeof(string), null, CultureInfo.GetCultureInfo("de"));
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Convert_MinInput_NullReturned()
+    {
+        var sut = new DateConverter();
+
+        var result = sut.Convert(DateTime.MinValue, typeof(string), null, CultureInfo.GetCultureInfo("de"));
+
+        result.Should().BeNull();
+    }
+    
+    [Theory]
+    [InlineData("de", "01.01.2023")]
+    [InlineData("en", "1/1/2023")]
+    public void Convert_ValidInput_FormattedReturned(string culture, string expectedResult)
+    {
+        var sut = new DateConverter();
+
+        var result = sut.Convert(
+            new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Local), typeof(string), null,
+            CultureInfo.GetCultureInfo(culture));
+
+        result.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void ConvertBack_Throws()
+    {
+        var sut = new DateConverter();
+        
+        sut.Invoking(x => x.ConvertBack(null, typeof(DateTime), null, CultureInfo.CurrentCulture)).Should()
+            .Throw<NotSupportedException>();
+    }
+}

--- a/tests/SimpleAccounting.UnitTests/Presentation/JournalItemBaseViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/JournalItemBaseViewModelTests.cs
@@ -1,0 +1,32 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.UnitTests.Presentation;
+
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using lg2de.SimpleAccounting.Presentation;
+using Xunit;
+
+public class JournalItemBaseViewModelTests
+{
+    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty")]
+    private class TestJournalItemBaseViewModel : JournalItemBaseViewModel;
+
+    [Fact]
+    public void IdentifierText_DefaultIdentifier_Empty()
+    {
+        var sut = new TestJournalItemBaseViewModel { Identifier = 0 };
+
+        sut.IdentifierText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void IdentifierText_SampleIdentifier_Formatted()
+    {
+        var sut = new TestJournalItemBaseViewModel { Identifier = 42 };
+
+        sut.IdentifierText.Should().Be("42");
+    }
+}


### PR DESCRIPTION
## Description
Fully hide the date and the identifier in the account journal summary rows.

## Related issue
Fixes #184
