### PR TITLE
Consolidate report layout

### DIFF
--- a/src/SimpleAccounting/Abstractions/IClock.cs
+++ b/src/SimpleAccounting/Abstractions/IClock.cs
@@ -6,6 +6,12 @@ namespace lg2de.SimpleAccounting.Abstractions;
 
 using System;
 
+/// <summary>
+///     Defines abstraction for getting current date and time.
+/// </summary>
+/// <remarks>
+///     S6354: Use a testable (date) time provider instead.
+/// </remarks>
 internal interface IClock
 {
     DateTime Now();

--- a/src/SimpleAccounting/Abstractions/IClock.cs
+++ b/src/SimpleAccounting/Abstractions/IClock.cs
@@ -1,0 +1,12 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.Abstractions;
+
+using System;
+
+internal interface IClock
+{
+    DateTime Now();
+}

--- a/src/SimpleAccounting/Abstractions/SystemClock.cs
+++ b/src/SimpleAccounting/Abstractions/SystemClock.cs
@@ -7,6 +7,9 @@ namespace lg2de.SimpleAccounting.Abstractions;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
+/// <summary>
+///     Default implementation of <see cref="IClock"/> using real time.
+/// </summary>
 [SuppressMessage(
     "Major Code Smell", "S6354:Use a testable date/time provider",
     Justification = "This is the one and only implementation according pattern.")]

--- a/src/SimpleAccounting/Abstractions/SystemClock.cs
+++ b/src/SimpleAccounting/Abstractions/SystemClock.cs
@@ -1,0 +1,19 @@
+// <copyright>
+//     Copyright (c) Lukas Grützmacher. All rights reserved.
+// </copyright>
+
+namespace lg2de.SimpleAccounting.Abstractions;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+[SuppressMessage(
+    "Major Code Smell", "S6354:Use a testable date/time provider",
+    Justification = "This is the one and only implementation according pattern.")]
+internal class SystemClock : IClock
+{
+    public DateTime Now()
+    {
+        return DateTime.Now;
+    }
+}

--- a/src/SimpleAccounting/AppBootstrapper.cs
+++ b/src/SimpleAccounting/AppBootstrapper.cs
@@ -44,6 +44,7 @@ public class AppBootstrapper : BootstrapperBase
             .Singleton<IFileSystem, FileSystem>()
             .Singleton<IProcess, DotNetProcess>();
         this.container.PerRequest<IHttpClient, DotNetHttpClient>();
+        this.container.Singleton<IClock, SystemClock>();
         this.container.PerRequest<ShellViewModel>();
     }
 

--- a/src/SimpleAccounting/Model/IProjectData.cs
+++ b/src/SimpleAccounting/Model/IProjectData.cs
@@ -54,7 +54,7 @@ internal interface IProjectData
 
     Task EditProjectOptionsAsync();
 
-    Task ShowAddBookingDialogAsync(bool showInactiveAccounts);
+    Task ShowAddBookingDialogAsync(DateTime today, bool showInactiveAccounts);
 
     Task ShowEditBookingDialogAsync(IJournalItem item, bool showInactiveAccounts);
 

--- a/src/SimpleAccounting/Model/ProjectData.cs
+++ b/src/SimpleAccounting/Model/ProjectData.cs
@@ -229,10 +229,10 @@ internal class ProjectData : IProjectData
         this.YearChanged(this, EventArgs.Empty);
     }
 
-    public async Task ShowAddBookingDialogAsync(bool showInactiveAccounts)
+    public async Task ShowAddBookingDialogAsync(DateTime today, bool showInactiveAccounts)
     {
         var bookingModel =
-            new EditBookingViewModel(this, DateTime.Today, editMode: false);
+            new EditBookingViewModel(this, today, editMode: false);
         var allAccounts = this.Storage.AllAccounts;
         bookingModel.Accounts.AddRange(showInactiveAccounts ? allAccounts : allAccounts.Where(x => x.Active));
         var bookingTemplates = this.Storage.Setup?.BookingTemplates;

--- a/src/SimpleAccounting/Presentation/EditBookingDesignViewModel.cs
+++ b/src/SimpleAccounting/Presentation/EditBookingDesignViewModel.cs
@@ -18,6 +18,10 @@ using lg2de.SimpleAccounting.Properties;
 [SuppressMessage(
     "Major Code Smell", "S4055:Literals should not be passed as localized parameters",
     Justification = "Design view model defines useful values")]
+[SuppressMessage(
+    "Major Code Smell",
+    "S6354:Use a testable date/time provider",
+    Justification = "Is ok for design view model.")]
 internal class EditBookingDesignViewModel : EditBookingViewModel
 {
     public EditBookingDesignViewModel()

--- a/src/SimpleAccounting/Presentation/ImportBookingsDesignViewModel.cs
+++ b/src/SimpleAccounting/Presentation/ImportBookingsDesignViewModel.cs
@@ -21,6 +21,10 @@ using lg2de.SimpleAccounting.Properties;
 [SuppressMessage(
     "Major Code Smell", "S4055:Literals should not be passed as localized parameters",
     Justification = "Design view model defines useful values")]
+[SuppressMessage(
+    "Major Code Smell",
+    "S6354:Use a testable date/time provider",
+    Justification = "Is ok for design view model.")]
 internal class ImportBookingsDesignViewModel : ImportBookingsViewModel
 {
     // define some accounts

--- a/src/SimpleAccounting/Presentation/MenuViewModel.cs
+++ b/src/SimpleAccounting/Presentation/MenuViewModel.cs
@@ -252,7 +252,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
     private void OnTotalJournalReport()
     {
         var report = this.reportFactory.CreateTotalJournal(this.projectData);
-        report.CreateReport(Resources.Header_Journal);
+        report.CreateReport();
         report.ShowPreview(Resources.Header_Journal);
     }
 
@@ -261,7 +261,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
         var report = this.reportFactory.CreateAccountJournal(this.projectData);
         report.PageBreakBetweenAccounts =
             this.projectData.Storage.Setup?.Reports?.AccountJournalReport?.PageBreakBetweenAccounts ?? false;
-        report.CreateReport(Resources.Header_AccountSheets);
+        report.CreateReport();
         report.ShowPreview(Resources.Header_AccountSheets);
     }
 
@@ -269,7 +269,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
     {
         var report = this.reportFactory.CreateTotalsAndBalances(
             this.projectData, this.projectData.Storage.Accounts);
-        report.CreateReport(Resources.Header_TotalsAndBalances);
+        report.CreateReport();
         report.ShowPreview(Resources.Header_TotalsAndBalances);
     }
 
@@ -291,7 +291,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
 
         var report = this.reportFactory.CreateTotalsAndBalances(this.projectData, accountGroups);
         this.projectData.Storage.Setup?.Reports?.TotalsAndBalancesReport?.ForEach(report.Signatures.Add);
-        report.CreateReport(Resources.Header_AssetBalances);
+        report.CreateReport();
         report.ShowPreview(Resources.Header_AssetBalances);
     }
 
@@ -299,7 +299,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
     {
         var report = this.reportFactory.CreateAnnualBalance(this.projectData);
         string title = Resources.Header_AnnualBalance;
-        report.CreateReport(title);
+        report.CreateReport();
         report.ShowPreview(title);
     }
 }

--- a/src/SimpleAccounting/Presentation/MenuViewModel.cs
+++ b/src/SimpleAccounting/Presentation/MenuViewModel.cs
@@ -26,22 +26,25 @@ using Screen = Caliburn.Micro.Screen;
 /// </summary>
 internal class MenuViewModel : Screen, IMenuViewModel
 {
-    private readonly IBusy busy;
-    private readonly IDialogs dialogs;
-    private readonly IProcess processApi;
     private readonly IProjectData projectData;
+    private readonly IBusy busy;
     private readonly IReportFactory reportFactory;
+    private readonly IClock clock;
+    private readonly IProcess processApi;
+    private readonly IDialogs dialogs;
 
     public MenuViewModel(
         IProjectData projectData,
         IBusy busy, IReportFactory reportFactory,
+        IClock clock,
         IProcess processApi, IDialogs dialogs)
     {
-        this.busy = busy;
         this.projectData = projectData;
+        this.busy = busy;
+        this.reportFactory = reportFactory;
+        this.clock = clock;
         this.processApi = processApi;
         this.dialogs = dialogs;
-        this.reportFactory = reportFactory;
     }
 
     public ICommand NewProjectCommand => new AsyncCommand(
@@ -90,7 +93,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
     public ObservableCollection<MenuItemViewModel> RecentProjects { get; } = [];
 
     public ICommand AddBookingsCommand => new AsyncCommand(
-        () => this.projectData.ShowAddBookingDialogAsync(this.projectData.ShowInactiveAccounts),
+        () => this.projectData.ShowAddBookingDialogAsync(this.clock.Now().Date, this.projectData.ShowInactiveAccounts),
         () => !this.projectData.CurrentYear.Closed);
 
     public ICommand DuplicateBookingsCommand => new AsyncCommand(

--- a/src/SimpleAccounting/Presentation/MenuViewModel.cs
+++ b/src/SimpleAccounting/Presentation/MenuViewModel.cs
@@ -272,7 +272,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
     {
         var report = this.reportFactory.CreateTotalsAndBalances(
             this.projectData, this.projectData.Storage.Accounts);
-        report.CreateReport();
+        report.CreateReport(Resources.Header_TotalsAndBalances);
         report.ShowPreview(Resources.Header_TotalsAndBalances);
     }
 
@@ -294,7 +294,7 @@ internal class MenuViewModel : Screen, IMenuViewModel
 
         var report = this.reportFactory.CreateTotalsAndBalances(this.projectData, accountGroups);
         this.projectData.Storage.Setup?.Reports?.TotalsAndBalancesReport?.ForEach(report.Signatures.Add);
-        report.CreateReport();
+        report.CreateReport(Resources.Header_AssetBalances);
         report.ShowPreview(Resources.Header_AssetBalances);
     }
 

--- a/src/SimpleAccounting/Presentation/ShellDesignViewModel.cs
+++ b/src/SimpleAccounting/Presentation/ShellDesignViewModel.cs
@@ -28,7 +28,7 @@ internal class ShellDesignViewModel : ShellViewModel
         : base(
             DesignProject,
             new BusyControlModel(),
-            new MenuViewModel(DesignProject, null!, null!, null!, null!),
+            new MenuViewModel(DesignProject, null!, null!, null!, null!, null!),
             new FullJournalViewModel(DesignProject),
             new AccountJournalViewModel(DesignProject), new AccountsViewModel(null!, DesignProject), null!)
     {

--- a/src/SimpleAccounting/Reports/AccountJournal.xml
+++ b/src/SimpleAccounting/Reports/AccountJournal.xml
@@ -3,17 +3,17 @@
 <xEport paperSize="A4" left="20" top="15" bottom="15" right="20">
   <pageTexts>
     <font size="8">
-      <text absX="85" absY="-5" align="center">- @Header_AccountSheets@ {yearName} -</text>
-      <text absX="85" absY="270" align="center">- @Word_Page@ {pageNumber} -</text>
+      <text absX="85" absY="-5" align="center">- @Header_AccountSheets@ #YearName# -</text>
+      <text absX="85" absY="270" align="center">- @Word_Page@ #PageNumber# -</text>
     </font>
   </pageTexts>
   <font size="20" />
   <text absX="85" align="center">@Header_AccountSheets@</text>
   <move relY="10" />
   <font size="10" />
-  <text ID="firm" absX="85" align="center">-Firm-</text>
+  <text absX="85" align="center">#Organization#</text>
   <move relY="5" />
-  <text ID="range" absX="85" align="center">-TimeRange-</text>
+  <text absX="85" align="center">#TimeRange#</text>
   <move relY="10" />
   <font size="8" />
   <table lineHeight="4">
@@ -28,5 +28,5 @@
     <data />
   </table>
   <move relY="10" />
-  <text ID="date" />
+  <text>#CurrentDate#</text>
 </xEport>

--- a/src/SimpleAccounting/Reports/AccountJournalReport.cs
+++ b/src/SimpleAccounting/Reports/AccountJournalReport.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Extensions;
 using lg2de.SimpleAccounting.Model;
 using lg2de.SimpleAccounting.Properties;
@@ -22,8 +23,8 @@ internal class AccountJournalReport : ReportBase, IAccountJournalReport
     private double debitTotal;
     private bool firstAccount;
 
-    public AccountJournalReport(IXmlPrinter printer, IProjectData projectData)
-        : base(printer, ResourceName, projectData)
+    public AccountJournalReport(IXmlPrinter printer, IProjectData projectData, IClock clock)
+        : base(ResourceName, printer, projectData, clock)
     {
         this.accounts = projectData.Storage.AllAccounts.OrderBy(a => a.ID);
     }
@@ -35,7 +36,7 @@ internal class AccountJournalReport : ReportBase, IAccountJournalReport
 
     public void CreateReport()
     {
-        this.PreparePrintDocument(DateTime.Now);
+        this.PreparePrintDocument();
 
         XmlNode tableNode = this.PrintDocument.SelectSingleNode("//table")!;
 

--- a/src/SimpleAccounting/Reports/AccountJournalReport.cs
+++ b/src/SimpleAccounting/Reports/AccountJournalReport.cs
@@ -33,9 +33,9 @@ internal class AccountJournalReport : ReportBase, IAccountJournalReport
     /// </summary>
     public bool PageBreakBetweenAccounts { get; set; }
 
-    public void CreateReport(string title)
+    public void CreateReport()
     {
-        this.PreparePrintDocument(title, DateTime.Now);
+        this.PreparePrintDocument(DateTime.Now);
 
         XmlNode tableNode = this.PrintDocument.SelectSingleNode("//table")!;
 
@@ -44,7 +44,8 @@ internal class AccountJournalReport : ReportBase, IAccountJournalReport
         foreach (var account in this.accounts)
         {
             var accountEntries = this.YearData.Booking
-                .Where(x => x.Debit.Exists(a => a.Account == account.ID) || x.Credit.Exists(a => a.Account == account.ID))
+                .Where(
+                    x => x.Debit.Exists(a => a.Account == account.ID) || x.Credit.Exists(a => a.Account == account.ID))
                 .OrderBy(x => x.Date)
                 .ThenBy(x => x.ID)
                 .ToList();

--- a/src/SimpleAccounting/Reports/AnnualBalance.xml
+++ b/src/SimpleAccounting/Reports/AnnualBalance.xml
@@ -2,12 +2,12 @@
 <!-- Copyright (c) Lukas Grützmacher. All rights reserved. -->
 <xEport paperSize="A4" left="20" top="15" bottom="15" right="20">
   <font size="20" />
-  <text absX="85" align="center">- @Header_AnnualBalance@ -</text>
+  <text absX="85" align="center">- @Header_AnnualBalance@ #YearName# -</text>
   <move relY="10" />
   <font size="10" />
-  <text ID="firm" absX="85" align="center">-Firm-</text>
+  <text absX="85" align="center">#Organization#</text>
   <move relY="5" />
-  <text absX="85" align="center">{yearName}</text>
+  <text absX="85" align="center">#TimeRange#</text>
   <move relY="10" />
   <font size="8" />
   <table lineHeight="4">
@@ -31,7 +31,7 @@
   </table>
   <move relY="10" />
   <text>@Report_AnnualNetProfitAndLoss@</text>
-  <text ID="balance" absX="160" align="right">xxx</text>
+  <text ID="balance" absX="160" align="right">-placeholder-</text>
   <move relY="20" />
   <table lineHeight="4">
     <columns>
@@ -63,5 +63,5 @@
     <data target="asset" />
   </table>
   <move relY="10" />
-  <text ID="date" />
+  <text>#CurrentDate#</text>
 </xEport>

--- a/src/SimpleAccounting/Reports/AnnualBalanceReport.cs
+++ b/src/SimpleAccounting/Reports/AnnualBalanceReport.cs
@@ -4,12 +4,12 @@
 
 namespace lg2de.SimpleAccounting.Reports;
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Extensions;
 using lg2de.SimpleAccounting.Model;
 using lg2de.SimpleAccounting.Properties;
@@ -22,15 +22,15 @@ internal class AnnualBalanceReport : ReportBase, IAnnualBalanceReport
 
     private readonly List<AccountDefinition> allAccounts;
 
-    public AnnualBalanceReport(IXmlPrinter printer, IProjectData projectData)
-        : base(printer, ResourceName, projectData)
+    public AnnualBalanceReport(IXmlPrinter printer, IProjectData projectData, IClock clock)
+        : base(ResourceName, printer, projectData, clock)
     {
         this.allAccounts = projectData.Storage.AllAccounts.ToList();
     }
 
     public void CreateReport()
     {
-        this.PreparePrintDocument(DateTime.Now);
+        this.PreparePrintDocument();
 
         // income / Einnahmen
         this.ProcessIncome(out var totalIncome);

--- a/src/SimpleAccounting/Reports/AnnualBalanceReport.cs
+++ b/src/SimpleAccounting/Reports/AnnualBalanceReport.cs
@@ -28,9 +28,9 @@ internal class AnnualBalanceReport : ReportBase, IAnnualBalanceReport
         this.allAccounts = projectData.Storage.AllAccounts.ToList();
     }
 
-    public void CreateReport(string title)
+    public void CreateReport()
     {
-        this.PreparePrintDocument(title, DateTime.Now);
+        this.PreparePrintDocument(DateTime.Now);
 
         // income / Einnahmen
         this.ProcessIncome(out var totalIncome);

--- a/src/SimpleAccounting/Reports/IAccountJournalReport.cs
+++ b/src/SimpleAccounting/Reports/IAccountJournalReport.cs
@@ -11,7 +11,7 @@ internal interface IAccountJournalReport
 {
     bool PageBreakBetweenAccounts { get; set; }
 
-    void CreateReport(string title);
+    void CreateReport();
 
     void ShowPreview(string documentName);
 }

--- a/src/SimpleAccounting/Reports/IAnnualBalanceReport.cs
+++ b/src/SimpleAccounting/Reports/IAnnualBalanceReport.cs
@@ -9,7 +9,7 @@ namespace lg2de.SimpleAccounting.Reports;
 /// </summary>
 internal interface IAnnualBalanceReport
 {
-    void CreateReport(string title);
+    void CreateReport();
 
     void ShowPreview(string documentName);
 }

--- a/src/SimpleAccounting/Reports/ITotalJournalReport.cs
+++ b/src/SimpleAccounting/Reports/ITotalJournalReport.cs
@@ -9,7 +9,7 @@ namespace lg2de.SimpleAccounting.Reports;
 /// </summary>
 internal interface ITotalJournalReport
 {
-    void CreateReport(string title);
+    void CreateReport();
 
     void ShowPreview(string documentName);
 }

--- a/src/SimpleAccounting/Reports/ITotalsAndBalancesReport.cs
+++ b/src/SimpleAccounting/Reports/ITotalsAndBalancesReport.cs
@@ -13,7 +13,7 @@ internal interface ITotalsAndBalancesReport
 {
     List<string> Signatures { get; }
 
-    void CreateReport(string title);
+    void CreateReport();
 
     void ShowPreview(string documentName);
 }

--- a/src/SimpleAccounting/Reports/ITotalsAndBalancesReport.cs
+++ b/src/SimpleAccounting/Reports/ITotalsAndBalancesReport.cs
@@ -13,7 +13,7 @@ internal interface ITotalsAndBalancesReport
 {
     List<string> Signatures { get; }
 
-    void CreateReport();
+    void CreateReport(string reportName);
 
     void ShowPreview(string documentName);
 }

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -47,6 +47,8 @@ internal class ReportBase
 
     protected void PreparePrintDocument()
     {
+        // Placeholders are identified by # in the template.
+        // Dictionary entries are identified by @ in the template. (Handled later while printing.)
         this.UpdatePlaceholder("Organization", this.setup.Name);
         this.UpdatePlaceholder("YearName", this.YearData.Year);
         string startDate = this.YearData.DateStart.ToDateTime().ToString("d", CultureInfo.CurrentCulture);

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -44,7 +44,7 @@ internal class ReportBase
         this.printer.PrintDocument($"{this.PrintingDate:yyyy-MM-dd} {documentName} {this.YearData.Year}");
     }
 
-    protected void PreparePrintDocument(string title, DateTime printDate)
+    protected void PreparePrintDocument(DateTime printDate)
     {
         this.UpdatePlaceholder("Organization", this.setup.Name);
         this.UpdatePlaceholder("YearName", this.YearData.Year);

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -58,7 +58,7 @@ internal class ReportBase
             "CurrentDate", this.setup.Location + ", " + this.printingDate.ToString("D", CultureInfo.CurrentCulture));
     }
 
-    private void UpdatePlaceholder(string name, string value)
+    protected void UpdatePlaceholder(string name, string value)
     {
         string placeholder = $"#{name}#";
         var elements = this.PrintDocument.SelectNodes($"//*[contains(text(),'{placeholder}')]")!;

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Extensions;
 using lg2de.SimpleAccounting.Model;
 
@@ -21,19 +22,19 @@ internal class ReportBase
 
     private readonly IXmlPrinter printer;
     private readonly AccountingDataSetup setup;
+    private readonly DateTime printingDate;
 
-    protected ReportBase(IXmlPrinter printer, string resourceName, IProjectData projectData)
+    protected ReportBase(string resourceName, IXmlPrinter printer, IProjectData projectData, IClock clock)
     {
         this.printer = printer;
         this.setup = projectData.Storage.Setup;
         this.YearData = projectData.CurrentYear;
+        this.printingDate = clock.Now();
 
         this.printer.LoadDocument(resourceName);
     }
 
     protected AccountingDataJournal YearData { get; }
-
-    protected DateTime PrintingDate { get; set; } = DateTime.Now;
 
     protected XmlDocument PrintDocument => this.printer.Document;
 
@@ -41,10 +42,10 @@ internal class ReportBase
 
     public void ShowPreview(string documentName)
     {
-        this.printer.PrintDocument($"{this.PrintingDate:yyyy-MM-dd} {documentName} {this.YearData.Year}");
+        this.printer.PrintDocument($"{this.printingDate:yyyy-MM-dd} {documentName} {this.YearData.Year}");
     }
 
-    protected void PreparePrintDocument(DateTime printDate)
+    protected void PreparePrintDocument()
     {
         this.UpdatePlaceholder("Organization", this.setup.Name);
         this.UpdatePlaceholder("YearName", this.YearData.Year);
@@ -52,7 +53,7 @@ internal class ReportBase
         string endDate = this.YearData.DateEnd.ToDateTime().ToString("d", CultureInfo.CurrentCulture);
         this.UpdatePlaceholder("TimeRange", $"{startDate} - {endDate}");
         this.UpdatePlaceholder(
-            "CurrentDate", this.setup.Location + ", " + printDate.ToString("D", CultureInfo.CurrentCulture));
+            "CurrentDate", this.setup.Location + ", " + this.printingDate.ToString("D", CultureInfo.CurrentCulture));
     }
 
     private void UpdatePlaceholder(string name, string value)

--- a/src/SimpleAccounting/Reports/ReportBase.cs
+++ b/src/SimpleAccounting/Reports/ReportBase.cs
@@ -46,44 +46,23 @@ internal class ReportBase
 
     protected void PreparePrintDocument(string title, DateTime printDate)
     {
-        var textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"title\"]");
-        if (textNode != null)
-        {
-            textNode.InnerText = title;
-        }
+        this.UpdatePlaceholder("Organization", this.setup.Name);
+        this.UpdatePlaceholder("YearName", this.YearData.Year);
+        string startDate = this.YearData.DateStart.ToDateTime().ToString("d", CultureInfo.CurrentCulture);
+        string endDate = this.YearData.DateEnd.ToDateTime().ToString("d", CultureInfo.CurrentCulture);
+        this.UpdatePlaceholder("TimeRange", $"{startDate} - {endDate}");
+        this.UpdatePlaceholder(
+            "CurrentDate", this.setup.Location + ", " + printDate.ToString("D", CultureInfo.CurrentCulture));
+    }
 
-        textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"pageTitle\"]");
-        if (textNode != null)
-        {
-            textNode.InnerText = $"- {title} -";
-        }
-
-        textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"firm\"]");
-        if (textNode != null)
-        {
-            textNode.InnerText = this.setup.Name;
-        }
-
-        var elements = this.PrintDocument.SelectNodes("//*[contains(text(),'yearName')]")!;
+    private void UpdatePlaceholder(string name, string value)
+    {
+        string placeholder = $"#{name}#";
+        var elements = this.PrintDocument.SelectNodes($"//*[contains(text(),'{placeholder}')]")!;
         foreach (var element in elements.OfType<XmlElement>())
         {
             element.InnerText = element.InnerText.Replace(
-                "{yearName}", this.YearData.Year, StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"range\"]");
-        if (textNode != null)
-        {
-            string startDate = this.YearData.DateStart.ToDateTime().ToString("d", CultureInfo.CurrentCulture);
-            string endDate = this.YearData.DateEnd.ToDateTime().ToString("d", CultureInfo.CurrentCulture);
-            textNode.InnerText = $"{startDate} - {endDate}";
-        }
-
-        textNode = this.PrintDocument.SelectSingleNode("//text[@ID=\"date\"]");
-        if (textNode != null)
-        {
-            textNode.InnerText =
-                this.setup.Location + ", " + printDate.ToString("D", CultureInfo.CurrentCulture);
+                placeholder, value, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/SimpleAccounting/Reports/ReportFactory.cs
+++ b/src/SimpleAccounting/Reports/ReportFactory.cs
@@ -6,33 +6,43 @@ namespace lg2de.SimpleAccounting.Reports;
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Model;
 
 /// <summary>
 ///     Implements <see cref="IReportFactory"/> using real report implementations.
 /// </summary>
 [ExcludeFromCodeCoverage]
+[UsedImplicitly]
 internal class ReportFactory : IReportFactory
 {
+    private readonly IClock clock;
+
+    public ReportFactory(IClock clock)
+    {
+        this.clock = clock;
+    }
+
     public IAccountJournalReport CreateAccountJournal(IProjectData projectData)
     {
-        return new AccountJournalReport(new XmlPrinter(), projectData);
+        return new AccountJournalReport(new XmlPrinter(), projectData, this.clock);
     }
 
     public ITotalJournalReport CreateTotalJournal(IProjectData projectData)
     {
-        return new TotalJournalReport(new XmlPrinter(), projectData);
+        return new TotalJournalReport(new XmlPrinter(), projectData, this.clock);
     }
 
     public IAnnualBalanceReport CreateAnnualBalance(IProjectData projectData)
     {
-        return new AnnualBalanceReport(new XmlPrinter(), projectData);
+        return new AnnualBalanceReport(new XmlPrinter(), projectData, this.clock);
     }
 
     public ITotalsAndBalancesReport CreateTotalsAndBalances(
         IProjectData projectData,
         IEnumerable<AccountingDataAccountGroup> accounts)
     {
-        return new TotalsAndBalancesReport(new XmlPrinter(), projectData, accounts);
+        return new TotalsAndBalancesReport(new XmlPrinter(), projectData, this.clock, accounts);
     }
 }

--- a/src/SimpleAccounting/Reports/TotalJournal.xml
+++ b/src/SimpleAccounting/Reports/TotalJournal.xml
@@ -3,17 +3,17 @@
 <xEport paperSize="A4" left="20" top="15" bottom="15" right="20">
   <pageTexts>
     <font size="8">
-      <text absX="85" absY="-5" align="center">- @Header_Journal@ {yearName} -</text>
-      <text absX="85" absY="270" align="center">- @Word_Page@ {pageNumber} -</text>
+      <text absX="85" absY="-5" align="center">- @Header_Journal@ #YearName# -</text>
+      <text absX="85" absY="270" align="center">- @Word_Page@ #PageNumber# -</text>
     </font>
   </pageTexts>
   <font size="20" />
   <text absX="85" align="center">@Header_Journal@</text>
   <move relY="10" />
   <font size="10" />
-  <text ID="firm" absX="85" align="center">-Firm-</text>
+  <text absX="85" align="center">#Organization#</text>
   <move relY="5" />
-  <text ID="range" absX="85" align="center">-TimeRange-</text>
+  <text absX="85" align="center">#TimeRange#</text>
   <move relY="10" />
   <font size="8" />
   <table lineHeight="4">
@@ -29,5 +29,5 @@
     <data />
   </table>
   <move relY="10" />
-  <text ID="date" />
+  <text>#CurrentDate#</text>
 </xEport>

--- a/src/SimpleAccounting/Reports/TotalJournalReport.cs
+++ b/src/SimpleAccounting/Reports/TotalJournalReport.cs
@@ -23,9 +23,9 @@ internal class TotalJournalReport : ReportBase, ITotalJournalReport
     {
     }
 
-    public void CreateReport(string title)
+    public void CreateReport()
     {
-        this.PreparePrintDocument(title, DateTime.Now);
+        this.PreparePrintDocument(DateTime.Now);
 
         XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data")!;
 

--- a/src/SimpleAccounting/Reports/TotalJournalReport.cs
+++ b/src/SimpleAccounting/Reports/TotalJournalReport.cs
@@ -4,10 +4,10 @@
 
 namespace lg2de.SimpleAccounting.Reports;
 
-using System;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Extensions;
 using lg2de.SimpleAccounting.Model;
 
@@ -18,14 +18,14 @@ internal class TotalJournalReport : ReportBase, ITotalJournalReport
 {
     public const string ResourceName = "TotalJournal.xml";
 
-    public TotalJournalReport(IXmlPrinter printer, IProjectData projectData)
-        : base(printer, ResourceName, projectData)
+    public TotalJournalReport(IXmlPrinter printer, IProjectData projectData, IClock clock)
+        : base(ResourceName, printer, projectData, clock)
     {
     }
 
     public void CreateReport()
     {
-        this.PreparePrintDocument(DateTime.Now);
+        this.PreparePrintDocument();
 
         XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data")!;
 

--- a/src/SimpleAccounting/Reports/TotalsAndBalances.xml
+++ b/src/SimpleAccounting/Reports/TotalsAndBalances.xml
@@ -3,12 +3,12 @@
 <xEport paperSize="A4" landscape="true" left="13" top="15" bottom="15" right="13">
   <pageTexts>
     <font size="8">
-        <text absX="135" absY="-5" align="center">- @Header_TotalsAndBalances@ #YearName# -</text>
+        <text ID="page-header" absX="135" absY="-5" align="center">- #ReportName# #YearName# -</text>
         <text absX="135" absY="180" align="center">- @Word_Page@ #PageNumber# -</text>
     </font>
   </pageTexts>
   <font size="20" />
-    <text absX="135" align="center">@Header_TotalsAndBalances@ #YearName#</text>
+    <text ID="report-header" absX="135" align="center">#ReportName# #YearName#</text>
   <move relY="10" />
   <font size="10" />
     <text absX="135" align="center">#Organization#</text>

--- a/src/SimpleAccounting/Reports/TotalsAndBalances.xml
+++ b/src/SimpleAccounting/Reports/TotalsAndBalances.xml
@@ -3,17 +3,17 @@
 <xEport paperSize="A4" landscape="true" left="13" top="15" bottom="15" right="13">
   <pageTexts>
     <font size="8">
-      <text ID="pageTitle" absX="135" absY="-5" align="center">- @Header_TotalsAndBalances@ -</text>
-      <text absX="135" absY="180" align="center">- @Word_Page@ {pageNumber} -</text>
+        <text absX="135" absY="-5" align="center">- @Header_TotalsAndBalances@ #YearName# -</text>
+        <text absX="135" absY="180" align="center">- @Word_Page@ #PageNumber# -</text>
     </font>
   </pageTexts>
   <font size="20" />
-  <text ID="title" absX="135" align="center">@Header_TotalsAndBalances@</text>
+    <text absX="135" align="center">@Header_TotalsAndBalances@ #YearName#</text>
   <move relY="10" />
   <font size="10" />
-  <text ID="firm" absX="135" align="center">-Firm-</text>
+    <text absX="135" align="center">#Organization#</text>
   <move relY="5" />
-  <text ID="range" absX="135" align="center">-TimeRange-</text>
+    <text absX="135" align="center">#TimeRange#</text>
   <move relY="10" />
   <font size="8" />
   <table lineHeight="4">
@@ -38,5 +38,5 @@
   </table>
   <signatures />
   <move relY="10" />
-  <text ID="date" />
+    <text>#CurrentDate#</text>
 </xEport>

--- a/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
+++ b/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
@@ -4,11 +4,11 @@
 
 namespace lg2de.SimpleAccounting.Reports;
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Extensions;
 using lg2de.SimpleAccounting.Model;
 using lg2de.SimpleAccounting.Properties;
@@ -42,8 +42,9 @@ internal class TotalsAndBalancesReport : ReportBase, ITotalsAndBalancesReport
     public TotalsAndBalancesReport(
         IXmlPrinter printer,
         IProjectData projectData,
+        IClock clock,
         IEnumerable<AccountingDataAccountGroup> accountGroups)
-        : base(printer, ResourceName, projectData)
+        : base(ResourceName, printer, projectData, clock)
     {
         this.accountGroups = accountGroups.ToList();
     }
@@ -52,7 +53,7 @@ internal class TotalsAndBalancesReport : ReportBase, ITotalsAndBalancesReport
 
     public void CreateReport()
     {
-        this.PreparePrintDocument(DateTime.Now);
+        this.PreparePrintDocument();
 
         XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data")!;
 

--- a/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
+++ b/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
@@ -51,9 +51,10 @@ internal class TotalsAndBalancesReport : ReportBase, ITotalsAndBalancesReport
 
     public List<string> Signatures { get; } = [];
 
-    public void CreateReport()
+    public void CreateReport(string reportName)
     {
         this.PreparePrintDocument();
+        this.UpdatePlaceholder("ReportName", reportName);
 
         XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data")!;
 

--- a/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
+++ b/src/SimpleAccounting/Reports/TotalsAndBalancesReport.cs
@@ -50,9 +50,9 @@ internal class TotalsAndBalancesReport : ReportBase, ITotalsAndBalancesReport
 
     public List<string> Signatures { get; } = [];
 
-    public void CreateReport(string title)
+    public void CreateReport()
     {
-        this.PreparePrintDocument(title, DateTime.Now);
+        this.PreparePrintDocument(DateTime.Now);
 
         XmlNode dataNode = this.PrintDocument.SelectSingleNode("//table/data")!;
 
@@ -160,7 +160,8 @@ internal class TotalsAndBalancesReport : ReportBase, ITotalsAndBalancesReport
     {
         if (this.YearData.Booking.TrueForAll(
                 b =>
-                    b.Debit.TrueForAll(x => x.Account != account.ID) && b.Credit.TrueForAll(x => x.Account != account.ID)))
+                    b.Debit.TrueForAll(x => x.Account != account.ID) &&
+                    b.Credit.TrueForAll(x => x.Account != account.ID)))
         {
             return;
         }

--- a/src/SimpleAccounting/Reports/XmlPrinter.cs
+++ b/src/SimpleAccounting/Reports/XmlPrinter.cs
@@ -618,7 +618,7 @@ internal class XmlPrinter : IXmlPrinter
             foreach (var element in textElements.OfType<XmlElement>())
             {
                 element.InnerText = element.InnerText.Replace(
-                    "{pageNumber}", pageNumberText, StringComparison.InvariantCultureIgnoreCase);
+                    "#PageNumber#", pageNumberText, StringComparison.InvariantCultureIgnoreCase);
             }
 
             insertParent.ParentNode!.InsertAfter(copiedChild, insertParent);

--- a/tests/SimpleAccounting.UnitTests/Presentation/ImportBookingsViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ImportBookingsViewModelTests.cs
@@ -248,9 +248,10 @@ public class ImportBookingsViewModelTests
         var projectData = Samples.SampleProjectData;
         var accountsViewModel = new AccountsViewModel(null!, projectData);
         var busy = Substitute.For<IBusy>();
+        var clock = Substitute.For<IClock>();
         var parent = new ShellViewModel(
             projectData, busy,
-            new MenuViewModel(projectData, busy, null!, null!, null!), new FullJournalViewModel(projectData),
+            new MenuViewModel(projectData, busy, null!, clock, null!, null!), new FullJournalViewModel(projectData),
             new AccountJournalViewModel(projectData), accountsViewModel, null!);
         var accounts = projectData.Storage.AllAccounts.ToList();
         var bankAccount = accounts.Single(x => x.Name == "Bank account");

--- a/tests/SimpleAccounting.UnitTests/Presentation/MenuViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/MenuViewModelTests.cs
@@ -36,7 +36,8 @@ public class MenuViewModelTests
         var projectData = new ProjectData(settings, null!, null!, fileSystem, null!);
         var dialogs = Substitute.For<IDialogs>();
         var busy = new BusyControlModel();
-        var sut = new MenuViewModel(projectData, busy, null!, null!, dialogs);
+        var clock = Substitute.For<IClock>();
+        var sut = new MenuViewModel(projectData, busy, null!, clock, null!, dialogs);
         long counter = 0;
         var tcs = new TaskCompletionSource<bool>();
         dialogs.ShowOpenFileDialog(Arg.Any<string>()).Returns((DialogResult.OK, "dummy"));
@@ -132,9 +133,10 @@ public class MenuViewModelTests
         var projectData = Substitute.For<IProjectData>();
         var busy = Substitute.For<IBusy>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var processApi = Substitute.For<IProcess>();
         var dialogs = Substitute.For<IDialogs>();
-        var sut = new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs);
+        var sut = new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs);
 
         sut.ProjectOptionsCommand.Execute(null);
 
@@ -397,9 +399,10 @@ public class MenuViewModelTests
         dialogs = Substitute.For<IDialogs>();
         var busy = Substitute.For<IBusy>();
         reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var settings = new Settings();
         projectData = new ProjectData(settings, windowManager, dialogs, fileSystem, processApi);
-        var sut = new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs);
+        var sut = new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs);
         return sut;
     }
 
@@ -411,9 +414,10 @@ public class MenuViewModelTests
         var dialogs = Substitute.For<IDialogs>();
         var busy = Substitute.For<IBusy>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var settings = new Settings();
         var projectData = new ProjectData(settings, windowManager, dialogs, fileSystem, processApi);
-        var sut = new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs);
+        var sut = new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs);
         return sut;
     }
 }

--- a/tests/SimpleAccounting.UnitTests/Presentation/MenuViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/MenuViewModelTests.cs
@@ -263,6 +263,7 @@ public class MenuViewModelTests
 
         sut.AssetBalancesReportCommand.Execute(null);
 
+        assetBalancesReport.Received(1).CreateReport(Resources.Header_AssetBalances);
         assetBalancesReport.Received(1)
             .ShowPreview(Arg.Is<string>(document => !string.IsNullOrEmpty(document)));
         reportFactory.Received(1).CreateTotalsAndBalances(
@@ -331,6 +332,7 @@ public class MenuViewModelTests
 
         sut.TotalsAndBalancesReportCommand.Execute(null);
 
+        totalsAndBalancesReport.Received(1).CreateReport(Resources.Header_TotalsAndBalances);
         totalsAndBalancesReport.Received(1)
             .ShowPreview(Arg.Is<string>(document => !string.IsNullOrEmpty(document)));
     }

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -124,6 +124,7 @@ public partial class ShellViewModelTests
     public async Task OnActivate_TwoRecentProjectsOneOnSecuredDrive_AllProjectListed()
     {
         var busy = Substitute.For<IBusy>();
+        var clock = Substitute.For<IClock>();
         var windowManager = Substitute.For<IWindowManager>();
         var applicationUpdate = Substitute.For<IApplicationUpdate>();
         var dialogs = Substitute.For<IDialogs>();
@@ -138,7 +139,7 @@ public partial class ShellViewModelTests
         var sut =
             new ShellViewModel(
                 projectData, busy,
-                new MenuViewModel(projectData, busy, null!, null!, null!), new FullJournalViewModel(projectData),
+                new MenuViewModel(projectData, busy, null!, clock, null!, null!), new FullJournalViewModel(projectData),
                 new AccountJournalViewModel(projectData), accountsViewModel, applicationUpdate);
         dialogs.ShowMessageBox(
                 Arg.Is<string>(s => s.Contains("Cryptomator", StringComparison.Ordinal)),
@@ -689,6 +690,7 @@ public partial class ShellViewModelTests
         var busy = Substitute.For<IBusy>();
         var windowManager = Substitute.For<IWindowManager>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var applicationUpdate = Substitute.For<IApplicationUpdate>();
         var dialogs = Substitute.For<IDialogs>();
         var fileSystem = Substitute.For<IFileSystem>();
@@ -700,7 +702,7 @@ public partial class ShellViewModelTests
             new ShellViewModel(
                 projectData,
                 busy,
-                new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs),
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
                 new FullJournalViewModel(projectData),
                 new AccountJournalViewModel(projectData), accountsViewModel, applicationUpdate);
         return sut;
@@ -711,6 +713,7 @@ public partial class ShellViewModelTests
         var busy = Substitute.For<IBusy>();
         windowManager = Substitute.For<IWindowManager>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var applicationUpdate = Substitute.For<IApplicationUpdate>();
         var dialogs = Substitute.For<IDialogs>();
         var fileSystem = Substitute.For<IFileSystem>();
@@ -721,7 +724,7 @@ public partial class ShellViewModelTests
         var sut =
             new ShellViewModel(
                 projectData, busy,
-                new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs),
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
                 new FullJournalViewModel(projectData), new AccountJournalViewModel(projectData),
                 accountsViewModel, applicationUpdate);
         return sut;
@@ -732,6 +735,7 @@ public partial class ShellViewModelTests
         var busy = Substitute.For<IBusy>();
         var windowManager = Substitute.For<IWindowManager>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         applicationUpdate = Substitute.For<IApplicationUpdate>();
         dialogs = Substitute.For<IDialogs>();
         var fileSystem = Substitute.For<IFileSystem>();
@@ -742,7 +746,7 @@ public partial class ShellViewModelTests
         var sut =
             new ShellViewModel(
                 projectData, busy,
-                new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs),
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
                 new FullJournalViewModel(projectData), new AccountJournalViewModel(projectData),
                 accountsViewModel, applicationUpdate);
         return sut;
@@ -753,6 +757,7 @@ public partial class ShellViewModelTests
         var busy = Substitute.For<IBusy>();
         var windowManager = Substitute.For<IWindowManager>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var applicationUpdate = Substitute.For<IApplicationUpdate>();
         dialogs = Substitute.For<IDialogs>();
         var fileSystem = Substitute.For<IFileSystem>();
@@ -763,7 +768,7 @@ public partial class ShellViewModelTests
         var sut =
             new ShellViewModel(
                 projectData, busy,
-                new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs),
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
                 new FullJournalViewModel(projectData), new AccountJournalViewModel(projectData),
                 accountsViewModel, applicationUpdate);
         return sut;
@@ -774,6 +779,7 @@ public partial class ShellViewModelTests
         var busy = Substitute.For<IBusy>();
         var windowManager = Substitute.For<IWindowManager>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var applicationUpdate = Substitute.For<IApplicationUpdate>();
         var dialogs = Substitute.For<IDialogs>();
         fileSystem = Substitute.For<IFileSystem>();
@@ -784,7 +790,7 @@ public partial class ShellViewModelTests
         var sut =
             new ShellViewModel(
                 projectData, busy,
-                new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs),
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
                 new FullJournalViewModel(projectData), new AccountJournalViewModel(projectData),
                 accountsViewModel, applicationUpdate);
         return sut;
@@ -795,6 +801,7 @@ public partial class ShellViewModelTests
         var busy = Substitute.For<IBusy>();
         var windowManager = Substitute.For<IWindowManager>();
         var reportFactory = Substitute.For<IReportFactory>();
+        var clock = Substitute.For<IClock>();
         var applicationUpdate = Substitute.For<IApplicationUpdate>();
         dialogs = Substitute.For<IDialogs>();
         fileSystem = Substitute.For<IFileSystem>();
@@ -805,7 +812,7 @@ public partial class ShellViewModelTests
         var sut =
             new ShellViewModel(
                 projectData, busy,
-                new MenuViewModel(projectData, busy, reportFactory, processApi, dialogs),
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
                 new FullJournalViewModel(projectData), new AccountJournalViewModel(projectData),
                 accountsViewModel, applicationUpdate);
         return sut;

--- a/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Presentation/ShellViewModelTests.cs
@@ -730,6 +730,28 @@ public partial class ShellViewModelTests
         return sut;
     }
 
+    private static ShellViewModel CreateSut(out IWindowManager windowManager, out IClock clock)
+    {
+        var busy = Substitute.For<IBusy>();
+        windowManager = Substitute.For<IWindowManager>();
+        var reportFactory = Substitute.For<IReportFactory>();
+        clock = Substitute.For<IClock>();
+        var applicationUpdate = Substitute.For<IApplicationUpdate>();
+        var dialogs = Substitute.For<IDialogs>();
+        var fileSystem = Substitute.For<IFileSystem>();
+        var processApi = Substitute.For<IProcess>();
+        var settings = new Settings();
+        var projectData = new ProjectData(settings, windowManager, dialogs, fileSystem, processApi);
+        var accountsViewModel = new AccountsViewModel(windowManager, projectData);
+        var sut =
+            new ShellViewModel(
+                projectData, busy,
+                new MenuViewModel(projectData, busy, reportFactory, clock, processApi, dialogs),
+                new FullJournalViewModel(projectData), new AccountJournalViewModel(projectData),
+                accountsViewModel, applicationUpdate);
+        return sut;
+    }
+
     private static ShellViewModel CreateSut(out IApplicationUpdate applicationUpdate, out IDialogs dialogs)
     {
         var busy = Substitute.For<IBusy>();

--- a/tests/SimpleAccounting.UnitTests/Reports/AccountJournalReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/AccountJournalReportTests.cs
@@ -31,7 +31,7 @@ public class AccountJournalReportTests
             PageBreakBetweenAccounts = pageBreakBetweenAccounts
         };
 
-        sut.CreateReport("dummy");
+        sut.CreateReport();
 
         var year = DateTime.Now.Year;
         var expectedBankAccount = string.Format(

--- a/tests/SimpleAccounting.UnitTests/Reports/AccountJournalReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/AccountJournalReportTests.cs
@@ -12,8 +12,10 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Reports;
 using lg2de.SimpleAccounting.UnitTests.Presentation;
+using NSubstitute;
 using Xunit;
 
 [SuppressMessage("ReSharper", "UseStringInterpolation")]
@@ -26,7 +28,8 @@ public class AccountJournalReportTests
     {
         var projectData = Samples.SampleProjectData;
         projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-        var sut = new AccountJournalReport(new XmlPrinter(), projectData)
+        var clock = Substitute.For<IClock>();
+        var sut = new AccountJournalReport(new XmlPrinter(), projectData, clock)
         {
             PageBreakBetweenAccounts = pageBreakBetweenAccounts
         };

--- a/tests/SimpleAccounting.UnitTests/Reports/AnnualBalanceReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/AnnualBalanceReportTests.cs
@@ -21,7 +21,7 @@ public class AnnualBalanceReportTests
         projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
         var sut = new AnnualBalanceReport(new XmlPrinter(), projectData);
 
-        sut.CreateReport("dummy");
+        sut.CreateReport();
 
         using var _ = new AssertionScope();
 

--- a/tests/SimpleAccounting.UnitTests/Reports/AnnualBalanceReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/AnnualBalanceReportTests.cs
@@ -8,8 +8,10 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Reports;
 using lg2de.SimpleAccounting.UnitTests.Presentation;
+using NSubstitute;
 using Xunit;
 
 public class AnnualBalanceReportTests
@@ -19,7 +21,8 @@ public class AnnualBalanceReportTests
     {
         var projectData = Samples.SampleProjectData;
         projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-        var sut = new AnnualBalanceReport(new XmlPrinter(), projectData);
+        var clock = Substitute.For<IClock>();
+        var sut = new AnnualBalanceReport(new XmlPrinter(), projectData, clock);
 
         sut.CreateReport();
 

--- a/tests/SimpleAccounting.UnitTests/Reports/ReportBaseTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/ReportBaseTests.cs
@@ -30,9 +30,9 @@ public class ReportBaseTests
             this.PrintingDate = dateTime;
         }
 
-        public new void PreparePrintDocument(string title, DateTime printDate)
+        public new void PreparePrintDocument(DateTime printDate)
         {
-            base.PreparePrintDocument(title, printDate);
+            base.PreparePrintDocument(printDate);
         }
     }
 
@@ -57,7 +57,7 @@ public class ReportBaseTests
         projectData.SelectYear(projectData.Storage.Journal[0].Year);
         var sut = new TestReport(printer, projectData);
 
-        sut.PreparePrintDocument("TheTitle", new DateTime(2021, 5, 5, 0, 0, 0, DateTimeKind.Local));
+        sut.PreparePrintDocument(new DateTime(2021, 5, 5, 0, 0, 0, DateTimeKind.Local));
 
         XDocument.Parse(sut.PrintDocument.OuterXml).Should().BeEquivalentTo(
             XDocument.Parse(
@@ -78,7 +78,7 @@ public class ReportBaseTests
         printer.Document.Returns(new XmlDocument());
         var sut = new TestReport(printer, Samples.SampleProjectData);
 
-        sut.Invoking(x => x.PreparePrintDocument("TheTitle", DateTime.Now)).Should().NotThrow();
+        sut.Invoking(x => x.PreparePrintDocument(DateTime.Now)).Should().NotThrow();
     }
 
     [Fact]

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalJournalReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalJournalReportTests.cs
@@ -7,8 +7,10 @@ namespace lg2de.SimpleAccounting.UnitTests.Reports;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Reports;
 using lg2de.SimpleAccounting.UnitTests.Presentation;
+using NSubstitute;
 using Xunit;
 
 public class TotalJournalReportTests
@@ -18,7 +20,8 @@ public class TotalJournalReportTests
     {
         var projectData = Samples.SampleProjectData;
         projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
-        var sut = new TotalJournalReport(new XmlPrinter(), projectData);
+        var clock = Substitute.For<IClock>();
+        var sut = new TotalJournalReport(new XmlPrinter(), projectData, clock);
 
         sut.CreateReport();
 

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalJournalReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalJournalReportTests.cs
@@ -20,13 +20,15 @@ public class TotalJournalReportTests
         projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
         var sut = new TotalJournalReport(new XmlPrinter(), projectData);
 
-        sut.CreateReport("dummy");
+        sut.CreateReport();
 
         var year = Samples.SampleProject.Journal[^1].Year;
         var expected = $@"
 <data>
   <tr topLine=""True"">
-    <td>1/1/{year}</td>
+    <td>1/1/{
+        year
+    }</td>
     <td>1</td>
     <td>Open 1</td>
     <td>100</td>
@@ -35,7 +37,9 @@ public class TotalJournalReportTests
     <td>1000.00</td>
   </tr>
   <tr topLine=""True"">
-    <td>1/1/{year}</td>
+    <td>1/1/{
+        year
+    }</td>
     <td>2</td>
     <td>Open 2</td>
     <td>990</td>
@@ -44,7 +48,9 @@ public class TotalJournalReportTests
     <td>3000.00</td>
   </tr>
   <tr topLine=""True"">
-    <td>1/28/{year}</td>
+    <td>1/28/{
+        year
+    }</td>
     <td>3</td>
     <td>Salary</td>
     <td>100</td>
@@ -71,7 +77,9 @@ public class TotalJournalReportTests
     <td>80.00</td>
   </tr>
   <tr topLine=""True"">
-    <td>1/29/{year}</td>
+    <td>1/29/{
+        year
+    }</td>
     <td>4</td>
     <td>Credit rate</td>
     <td>5000</td>
@@ -80,7 +88,9 @@ public class TotalJournalReportTests
     <td>400.00</td>
   </tr>
   <tr topLine=""True"">
-    <td>2/1/{year}</td>
+    <td>2/1/{
+        year
+    }</td>
     <td>5</td>
     <td>Shoes1</td>
     <td>600</td>
@@ -107,7 +117,9 @@ public class TotalJournalReportTests
     <td>50.00</td>
   </tr>
   <tr topLine=""True"">
-    <td>2/5/{year}</td>
+    <td>2/5/{
+        year
+    }</td>
     <td>6</td>
     <td>Rent to friend</td>
     <td>6000</td>

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
@@ -22,7 +22,7 @@ public class TotalsAndBalancesReportTests
         var sut = new TotalsAndBalancesReport(
             new XmlPrinter(), projectData, projectData.Storage.Accounts);
 
-        sut.CreateReport("dummy");
+        sut.CreateReport();
 
         var year = Samples.SampleProject.Journal[^1].Year;
         var expected = $@"
@@ -30,7 +30,9 @@ public class TotalsAndBalancesReportTests
   <tr topLine=""True"">
     <td>100</td>
     <td>Bank account</td>
-    <td>2/5/{year}</td>
+    <td>2/5/{
+        year
+    }</td>
     <td>1000.00</td>
     <td></td>
     <td>200.00</td>
@@ -41,7 +43,9 @@ public class TotalsAndBalancesReportTests
   <tr topLine=""True"">
     <td>400</td>
     <td>Salary</td>
-    <td>1/28/{year}</td>
+    <td>1/28/{
+        year
+    }</td>
     <td></td>
     <td></td>
     <td></td>
@@ -52,7 +56,9 @@ public class TotalsAndBalancesReportTests
   <tr topLine=""True"">
     <td>600</td>
     <td>Shoes</td>
-    <td>2/1/{year}</td>
+    <td>2/1/{
+        year
+    }</td>
     <td></td>
     <td></td>
     <td>50.00</td>
@@ -63,7 +69,9 @@ public class TotalsAndBalancesReportTests
   <tr topLine=""True"">
     <td>990</td>
     <td>Carryforward</td>
-    <td>1/1/{year}</td>
+    <td>1/1/{
+        year
+    }</td>
     <td>2000.00</td>
     <td></td>
     <td></td>
@@ -85,7 +93,9 @@ public class TotalsAndBalancesReportTests
   <tr topLine=""True"">
     <td>5000</td>
     <td>Bank credit</td>
-    <td>1/29/{year}</td>
+    <td>1/29/{
+        year
+    }</td>
     <td></td>
     <td>3000.00</td>
     <td>400.00</td>
@@ -96,7 +106,9 @@ public class TotalsAndBalancesReportTests
   <tr topLine=""True"">
     <td>6000</td>
     <td>Friends debit</td>
-    <td>2/5/{year}</td>
+    <td>2/5/{
+        year
+    }</td>
     <td></td>
     <td></td>
     <td>99.00</td>
@@ -139,7 +151,7 @@ public class TotalsAndBalancesReportTests
             new XmlPrinter(), projectData, projectData.Storage.Accounts);
         sut.Signatures.Add("The Name");
 
-        sut.CreateReport("dummy");
+        sut.CreateReport();
 
         sut.DocumentForTests.XPathSelectElements("//text[@tag='signature']")
             .Select(x => x.Value).Should().Equal("The Name");

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
@@ -8,8 +8,10 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using FluentAssertions;
+using lg2de.SimpleAccounting.Abstractions;
 using lg2de.SimpleAccounting.Reports;
 using lg2de.SimpleAccounting.UnitTests.Presentation;
+using NSubstitute;
 using Xunit;
 
 public class TotalsAndBalancesReportTests
@@ -19,8 +21,9 @@ public class TotalsAndBalancesReportTests
     {
         var projectData = Samples.SampleProjectData;
         projectData.CurrentYear.Booking.AddRange(Samples.SampleBookings);
+        var clock = Substitute.For<IClock>();
         var sut = new TotalsAndBalancesReport(
-            new XmlPrinter(), projectData, projectData.Storage.Accounts);
+            new XmlPrinter(), projectData, clock, projectData.Storage.Accounts);
 
         sut.CreateReport();
 
@@ -147,8 +150,9 @@ public class TotalsAndBalancesReportTests
     public void CreateReport_SampleWithSignature_SignatureLinesCreated()
     {
         var projectData = Samples.SampleProjectData;
+        var clock = Substitute.For<IClock>();
         var sut = new TotalsAndBalancesReport(
-            new XmlPrinter(), projectData, projectData.Storage.Accounts);
+            new XmlPrinter(), projectData, clock, projectData.Storage.Accounts);
         sut.Signatures.Add("The Name");
 
         sut.CreateReport();

--- a/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/TotalsAndBalancesReportTests.cs
@@ -4,6 +4,7 @@
 
 namespace lg2de.SimpleAccounting.UnitTests.Reports;
 
+using System;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -25,7 +26,7 @@ public class TotalsAndBalancesReportTests
         var sut = new TotalsAndBalancesReport(
             new XmlPrinter(), projectData, clock, projectData.Storage.Accounts);
 
-        sut.CreateReport();
+        sut.CreateReport("-TotalsAndBalances-");
 
         var year = Samples.SampleProject.Journal[^1].Year;
         var expected = $@"
@@ -155,9 +156,27 @@ public class TotalsAndBalancesReportTests
             new XmlPrinter(), projectData, clock, projectData.Storage.Accounts);
         sut.Signatures.Add("The Name");
 
-        sut.CreateReport();
+        sut.CreateReport("-TotalsAndBalances-");
 
         sut.DocumentForTests.XPathSelectElements("//text[@tag='signature']")
             .Select(x => x.Value).Should().Equal("The Name");
+    }
+
+    [Theory]
+    [InlineData("Report 1")]
+    [InlineData("Report 2")]
+    public void CreateReport_ReportNames_NameAppliedToHeaderAndTitle(string reportName)
+    {
+        var projectData = Samples.SampleProjectData;
+        var clock = Substitute.For<IClock>();
+        var sut = new TotalsAndBalancesReport(
+            new XmlPrinter(), projectData, clock, projectData.Storage.Accounts);
+
+        sut.CreateReport(reportName);
+
+        var expectedText = $"- {reportName} {DateTime.Today.Year} -";
+        sut.DocumentForTests.XPathSelectElement("//text[@ID='page-header']")?.Value.Should().Be(expectedText);
+        expectedText = $"{reportName} {DateTime.Today.Year}";
+        sut.DocumentForTests.XPathSelectElement("//text[@ID='report-header']")?.Value.Should().Be(expectedText);
     }
 }

--- a/tests/SimpleAccounting.UnitTests/Reports/XmlPrinterTests.cs
+++ b/tests/SimpleAccounting.UnitTests/Reports/XmlPrinterTests.cs
@@ -488,33 +488,35 @@ public class XmlPrinterTests
     {
         var sut = new XmlPrinter { DocumentHeight = 10 };
         sut.LoadXml(
-            "<root>"
-            + "<pageTexts><font><text>page {pageNumber}</text></font></pageTexts>"
-            + "<table><columns>"
-            + "<column width=\"10\">C1</column>"
-            + "</columns><data>"
-            + "<tr><td>1</td></tr>"
-            + "<tr><td>2</td></tr>"
-            + "</data></table>"
-            + "</root>");
+            """
+            <root>
+              <pageTexts><font><text>page #PageNumber#</text></font></pageTexts>
+              <table>
+                <columns><column width="10">C1</column></columns>
+                <data><tr><td>1</td></tr><tr><td>2</td></tr></data>
+              </table>
+            </root>
+            """);
 
         var graphics = Substitute.For<IGraphics>();
         sut.TransformDocument(graphics);
 
         XDocument.Parse(sut.Document.OuterXml).Should().BeEquivalentTo(
             XDocument.Parse(
-                "<root>"
-                + "<font><text>page 1</text></font>"
-                + "<text relX=\"0\">C1</text>"
-                + "<move relY=\"4\" />"
-                + "<text relX=\"0\">1</text>"
-                + "<newPage />"
-                + "<font><text>page 2</text></font>"
-                + "<text relX=\"0\">C1</text>"
-                + "<move relY=\"4\" />"
-                + "<text relX=\"0\">2</text>"
-                + "<move relY=\"4\" />"
-                + "</root>"));
+                """
+                <root>
+                  <font><text>page 1</text></font>
+                  <text relX="0">C1</text>
+                  <move relY="4" />
+                  <text relX="0">1</text>
+                  <newPage />
+                  <font><text>page 2</text></font>
+                  <text relX="0">C1</text>
+                  <move relY="4" />
+                  <text relX="0">2</text>
+                  <move relY="4" />
+                </root>
+                """));
     }
 
     [Fact]


### PR DESCRIPTION
## Description
The reports were previously not that usable if the booking year is not identical to the calendar year.
Now all reports use the same design to show the full date for the booking year.

By the way the IClock interface has been introduced to get an abstraction for date and time, fixing some S6354 issues